### PR TITLE
fix ssh keys management & available slaves for bond

### DIFF
--- a/integral_view/templates/key_management_base.html
+++ b/integral_view/templates/key_management_base.html
@@ -1,8 +1,11 @@
 {% extends 'logged_in_base.html' %}
 
 {%block tab_items %}
-  <li id="download_ssh_keys_tab">
-    <a href="/download_ssh_keys/">SSH keys</a>
+  <li id="user_ssh_keys_tab">
+    <a href="/user_ssh_keys/">User SSH keys</a>
+  </li> 
+  <li id="host_ssh_keys_tab">
+    <a href="/known_hosts_ssh_keys/">Known Hosts SSH keys</a>
   </li>
   <li id="ssl_certs_tab">
     <a href="/view_ssl_certificates" >SSL certificates and keys</a>

--- a/integral_view/templates/known_hosts_ssh_keys.html
+++ b/integral_view/templates/known_hosts_ssh_keys.html
@@ -1,0 +1,69 @@
+{% extends  'key_management_base.html' %}
+
+{% block tab_header %}
+   Known hosts SSH keys for {{selected_user}}
+{% endblock%}
+
+{%block global_actions %}
+  <div class="btn-group btn-group-sm pull-right">
+    <a class="btn btn-default dropdown-toggle" data-toggle="dropdown" href="#">       <i class="fa fa-cog fa-fw"></i>&nbsp;Actions &nbsp;<span class="fa fa-caret-down" title="Toggle dropdown menu"></span> 
+    </a>
+
+    <ul class="dropdown-menu">
+
+      <li><a class="action-dropdown" href="/static/{{host_key}}" ><i class="fa fa-download fa-fw"></i>&nbsp;Download this system's SSH fingerprint</a></li>
+
+      <hr style="margin-top: 2px; margin-bottom: 2px; border: 0; border-top: 1px solid #7d7676;">
+      <li><a class="action-dropdown" href="/upload_ssh_host_key/?user={{selected_user}}" ><i class="fa fa-upload fa-fw"></i>&nbsp;Add SSH fingerprint to {{selected_user}} </a></li>
+
+    </ul>
+  </div>
+
+{% endblock  %}
+
+{% block inside_content %}
+  <table class="table" style="width:800px">
+    <tr>
+      <th> Select User :</th>
+      <td> 
+        <select name="user" id="id_user" class="form-control">
+<!--          {% for user in users %}
+            <option value="{{user.username}}" {% if user.username == selected_user%} selected="selected" {% endif %}>{{user.username}}</option>
+          {%endfor%}
+-->
+            <option value="replicator" {% if "replicator" == selected_user%} selected="selected" {% endif %}>replicator</option>
+        </select>
+      </td>
+    </tr>
+
+  </table>
+
+  {%if hosts_keys %}
+    User's known host key(s) 
+    <table class="table">
+      <tbody>
+        {% for key in hosts_keys %}    
+          <form action="/upload_ssh_host_key/" method="POST" class="form-horizontal">      
+            <tr>
+              <td >
+                <input type="text" value="{{selected_user}}" name="selected_user" readonly class="form-control" style="display:none"/>
+                <input type="text" value="{{key}}" name="authorized_key" readonly class="form-control" style="display:none"/>
+                <textarea cols=100 rows=4 readonly> {{key}} </textarea>
+              </td>
+              <td><button class="btn btn-danger">Remove Access </button></td>
+            </tr>
+          </form>
+        {% endfor %}
+      </tbody>
+    </table>
+  {%endif%}
+
+
+  <script>
+    document.getElementById("id_user").onchange = function () {
+      var user = $("#id_user").val()
+      location.href = "/known_hosts_ssh_keys/?user="+user
+    }
+  </script>
+{% endblock %}
+

--- a/integral_view/templates/logged_in_base.html
+++ b/integral_view/templates/logged_in_base.html
@@ -124,7 +124,7 @@
               </li>
               <hr style="margin-top: 2px; margin-bottom: 2px; border: 0; border-top: 1px solid #7d7676;">
               <li id="key_management_menu">
-                <a href="/download_ssh_keys/">
+                <a href="/user_ssh_keys/">
                   <i class="fa fa-key"></i> Keys and Certificates
                 </a>
               </li>

--- a/integral_view/templates/user_ssh_keys.html
+++ b/integral_view/templates/user_ssh_keys.html
@@ -1,0 +1,69 @@
+{% extends  'key_management_base.html' %}
+
+{% block tab_header %}
+   User SSH keys for {{selected_user}}
+{% endblock%}
+
+{%block global_actions %}
+  <div class="btn-group btn-group-sm pull-right">
+    <a class="btn btn-default dropdown-toggle" data-toggle="dropdown" href="#">       <i class="fa fa-cog fa-fw"></i>&nbsp;Actions &nbsp;<span class="fa fa-caret-down" title="Toggle dropdown menu"></span> 
+    </a>
+
+    <ul class="dropdown-menu">
+
+      <li><a class="action-dropdown" href="/static/{{ssh_key}}" ><i class="fa fa-download fa-fw"></i>&nbsp;Download {{selected_user}}'s public key</a></li>
+
+      <hr style="margin-top: 2px; margin-bottom: 2px; border: 0; border-top: 1px solid #7d7676;">
+      <li><a class="action-dropdown" href="/upload_ssh_user_key/?user={{selected_user}}" ><i class="fa fa-upload fa-fw"></i>&nbsp;Add authorized key for {{selected_user}} </a></li>
+
+    </ul>
+  </div>
+
+{% endblock  %}
+
+{% block inside_content %}
+  <table class="table" style="width:800px">
+    <tr>
+      <th> Select User :</th>
+      <td> 
+        <select name="user" id="id_user" class="form-control">
+<!--          {% for user in users %}
+            <option value="{{user.username}}" {% if user.username == selected_user%} selected="selected" {% endif %}>{{user.username}}</option>
+          {%endfor%}
+-->
+            <option value="replicator" {% if "replicator" == selected_user%} selected="selected" {% endif %}>replicator</option>
+        </select>
+      </td>
+    </tr>
+
+  </table>
+
+
+  {%if authorized_keys %}
+    Users Accepted SSH Key(s)
+    <table class="table">
+      <tbody>
+        {% for key in authorized_keys %}    
+          <form action="/upload_ssh_user_key/" method="POST" class="form-horizontal">      
+            <tr>
+              <td >
+                <input type="text" value="{{selected_user}}" name="selected_user" readonly class="form-control" style="display:none"/>
+                <input type="text" value="{{key}}" name="authorized_key" readonly class="form-control" style="display:none"/>
+                <textarea cols=100 rows=4 readonly> {{key}} </textarea>
+              </td>
+              <td><button class="btn btn-danger">Remove Access </button></td>
+            </tr>
+          </form>
+        {% endfor %}
+      </tbody>
+    </table>
+  {%endif%}
+
+  <script>
+    document.getElementById("id_user").onchange = function () {
+      var user = $("#id_user").val()
+      location.href = "/user_ssh_keys/?user="+user
+    }
+  </script>
+{% endblock %}
+

--- a/integral_view/urls.py
+++ b/integral_view/urls.py
@@ -6,7 +6,7 @@ from integral_view.views.ntp_management import configure_ntp_settings, view_ntp_
 
 from integral_view.views.admin_auth  import login, logout, change_admin_password, view_email_settings, configure_email_settings, view_https_mode, edit_https_mode, reboot_or_shutdown, reload_manifest, reset_to_factory_defaults, flag_node, view_system_info
 
-from integral_view.views.pki_management  import view_ssl_certificates, delete_ssl_certificate, create_self_signed_ssl_certificate, upload_ssl_certificate, download_ssh_keys, upload_ssh_user_key,upload_ssh_host_key
+from integral_view.views.pki_management  import view_ssl_certificates, delete_ssl_certificate, create_self_signed_ssl_certificate, upload_ssl_certificate, known_hosts_ssh_keys, user_ssh_keys, upload_ssh_user_key, upload_ssh_host_key
 
 from integral_view.views.common import show, dashboard,shell_access, view_backup
 
@@ -203,7 +203,8 @@ urlpatterns = patterns('',
     url(r'^create_ftp_user_dirs', login_required(create_ftp_user_dirs)),
     url(r'^view_ftp_configuration', login_required(view_ftp_configuration)),
     url(r'^reboot_or_shutdown',login_required(reboot_or_shutdown)), 
-    url(r'^download_ssh_keys',login_required(download_ssh_keys)),
+    url(r'^user_ssh_keys',login_required(user_ssh_keys)),
+    url(r'^known_hosts_ssh_keys',login_required(known_hosts_ssh_keys)),
     url(r'^upload_ssh_user_key',login_required(upload_ssh_user_key)),
     url(r'^upload_ssh_host_key',login_required(upload_ssh_host_key)),
     url(r'^create_rsync_share',login_required(create_rsync_share)),

--- a/integral_view/views/pki_management.py
+++ b/integral_view/views/pki_management.py
@@ -153,7 +153,7 @@ def upload_ssh_user_key(request):
         if err:
           raise Exception(err)
         ack_message = "key_added"
-      return django.http.HttpResponseRedirect("/download_ssh_keys/?ack=%s&user=%s"%(ack_message,user))
+      return django.http.HttpResponseRedirect("/user_ssh_keys/?ack=%s&user=%s"%(ack_message,user))
     except Exception,e:
       return_dict['base_template'] = "key_management_base.html"
       return_dict["page_title"] = 'Upload a Public Key'
@@ -207,7 +207,7 @@ def upload_ssh_host_key(request):
         if err:
           raise Exception(err)
         ack_message = "host_added"
-      return django.http.HttpResponseRedirect("/download_ssh_keys/?ack=%s&user=%s"%(ack_message,user))
+      return django.http.HttpResponseRedirect("/known_hosts_ssh_keys/?ack=%s&user=%s"%(ack_message,user))
     except Exception,e:
       return_dict['base_template'] = "key_management_base.html"
       return_dict["page_title"] = 'Upload a Host Key'
@@ -219,7 +219,7 @@ def upload_ssh_host_key(request):
   elif request.method == 'GET':
     return django.shortcuts.render_to_response("upload_ssh_host_key.html", return_dict, context_instance=django.template.context.RequestContext(request))
 
-def download_ssh_keys(request):
+def user_ssh_keys(request):
   return_dict = {}
   try:
     """
@@ -241,33 +241,31 @@ def download_ssh_keys(request):
       raise Exception(err)
     return_dict['ssh_key'] = key
 
-    host_key,err = pki.get_ssh_host_identity_key()
+    """host_key,err = pki.get_ssh_host_identity_key()
     if err:
       raise Exception(err)
-    return_dict['host_key'] = host_key
+    return_dict['host_key'] = host_key"""
 
     # Get all the users authorized key files
     authorized_keys_file = pki._get_authorized_file(user)
     if os.path.isfile(authorized_keys_file):
       return_dict["authorized_keys"] = open(authorized_keys_file,'r').readlines()
 
+    """
     # Get users host key files
     hosts_keys_file = pki._get_known_hosts(user)
     if os.path.isfile(hosts_keys_file):
       return_dict["hosts_keys"] = open(hosts_keys_file,'r').readlines()
+    """
 
     if "ack" in request.GET:
-      if request.GET["ack"] == "host_deleted":
-        return_dict['ack_message'] = "The Host Key has been successfully deleted"
       if request.GET["ack"] == "key_deleted":
         return_dict['ack_message'] = "The Public Key has been successfully deleted"
-      if request.GET["ack"] == "host_added":
-        return_dict['ack_message'] = "The Host Key has been successfully added"
       if request.GET["ack"] == "key_added":
         return_dict['ack_message'] = "The Public Key has been successfully added"
 
 
-    return django.shortcuts.render_to_response("download_ssh_keys.html", return_dict, context_instance=django.template.context.RequestContext(request))
+    return django.shortcuts.render_to_response("user_ssh_keys.html", return_dict, context_instance=django.template.context.RequestContext(request))
   except Exception,e:
     return_dict['base_template'] = "key_management_base.html"
     return_dict["page_title"] = 'My Keys'
@@ -275,3 +273,63 @@ def download_ssh_keys(request):
     return_dict["error"] = 'Error fetching public keys'
     return_dict["error_details"] = str(e)
     return django.shortcuts.render_to_response("logged_in_error.html", return_dict, context_instance=django.template.context.RequestContext(request))
+
+def known_hosts_ssh_keys(request):
+  return_dict = {}
+  try:
+    """
+    # This gets the users in the local account. Commented since, we dont have a need yet.
+    user_list, err = local_users.get_local_users()
+    if err:
+      raise Exception(err)
+    if len(user_list) == 0:
+      raise Exception("No users exists. Create a user")
+
+    return_dict["users"] = user_list
+    """
+
+    user = request.GET.get('user','replicator')
+    return_dict["selected_user"] = user
+
+    """
+    key,err = pki.get_ssh_key(user) 
+    if err:
+      raise Exception(err)
+    return_dict['ssh_key'] = key
+    """
+
+    host_key,err = pki.get_ssh_host_identity_key()
+    if err:
+      raise Exception(err)
+    return_dict['host_key'] = host_key
+
+    """
+    # Get all the users authorized key files
+    authorized_keys_file = pki._get_authorized_file(user)
+    if os.path.isfile(authorized_keys_file):
+      return_dict["authorized_keys"] = open(authorized_keys_file,'r').readlines()
+    """
+    
+    # Get users host key files
+    hosts_keys_file = pki._get_known_hosts(user)
+    if os.path.isfile(hosts_keys_file):
+      return_dict["hosts_keys"] = open(hosts_keys_file,'r').readlines()
+    
+
+    if "ack" in request.GET:
+      if request.GET["ack"] == "host_deleted":
+        return_dict['ack_message'] = "The Host Key has been successfully deleted"
+      if request.GET["ack"] == "host_added":
+        return_dict['ack_message'] = "The Host Key has been successfully added"
+
+
+    return django.shortcuts.render_to_response("known_hosts_ssh_keys.html", return_dict, context_instance=django.template.context.RequestContext(request))
+  except Exception,e:
+    return_dict['base_template'] = "key_management_base.html"
+    return_dict["page_title"] = 'My Keys'
+    return_dict['tab'] = 'my_public_key_tab'
+    return_dict["error"] = 'Error fetching public keys'
+    return_dict["error_details"] = str(e)
+    return django.shortcuts.render_to_response("logged_in_error.html", return_dict, context_instance=django.template.context.RequestContext(request))
+
+


### PR DESCRIPTION
In **_Keys and Certificates_** menu:

- Two new tabs - '_User ssh keys_' & '_Known hosts ssh keys_'
- Removed tab - '_SSH keys_'

**_User ssh keys_** tab:
![image](https://cloud.githubusercontent.com/assets/21103199/22649637/d8aae570-eca1-11e6-8baa-946e191bd66f.png)

On adding two authorized keys -
![image](https://cloud.githubusercontent.com/assets/21103199/22649630/ccfbba9c-eca1-11e6-999b-257ef84f5b71.png)


**_Known hosts ssh keys_** tab:
![image](https://cloud.githubusercontent.com/assets/21103199/22649620/c232f5e4-eca1-11e6-90a0-6ef5d07e6203.png)

On adding two fingerprints/known hosts:
![image](https://cloud.githubusercontent.com/assets/21103199/22649608/b31a0b10-eca1-11e6-92ff-1deadfd1d9d3.png)
