### PR TITLE
New class form for zvol & autoincrement primary keys of select tables

### DIFF
--- a/config/db/schemas
+++ b/config/db/schemas
@@ -69,7 +69,7 @@ CREATE TABLE "rsync_shares" (
 );
 
 CREATE TABLE "tasks" (
-  "task_id" integer NOT NULL PRIMARY KEY,
+  "task_id" integer NOT NULL PRIMARY KEY AUTOINCREMENT,
   "description" varchar(200) NOT NULL,
   "task_type_id" integer NOT NULL,
   "node" varchar(200) NOT NULL,
@@ -85,7 +85,7 @@ CREATE TABLE "tasks" (
 );
 
 CREATE TABLE "subtasks" (
-  "subtask_id" integer NOT NULL PRIMARY KEY,
+  "subtask_id" integer NOT NULL PRIMARY KEY AUTOINCREMENT,
   "description" varchar(100) NOT NULL,
   "command"  varchar(400) NOT NULL,
   "task_id" integer NOT NULL,
@@ -106,13 +106,13 @@ insert into task_types (task_type_id, description) values (3, 'ZFS scrub');
 insert into task_types (task_type_id, description) values (4, 'Remote replication');
 
 CREATE TABLE "cron_tasks" (
-  "cron_task_id" integer NOT NULL PRIMARY KEY,
+  "cron_task_id" integer NOT NULL PRIMARY KEY AUTOINCREMENT,
   "description" varchar(200) NOT NULL,
   "command" varchar(200) NOT NULL
 );
 
 CREATE TABLE "remote_replications" (
-  "remote_replication_id" integer NOT NULL PRIMARY KEY,
+  "remote_replication_id" integer NOT NULL PRIMARY KEY AUTOINCREMENT,
   "source_dataset" varchar(100) NOT NULL,
   "destination_ip" varchar(100) NOT NULL,
   "destination_user_name" varchar(100) NOT NULL,

--- a/integral_view/forms/zfs_forms.py
+++ b/integral_view/forms/zfs_forms.py
@@ -11,6 +11,12 @@ class DatasetForm(forms.Form):
     ch = [('G', 'GB'), ('M', 'MB')]
     quota_unit = forms.ChoiceField(choices=ch)
 
+class ZvolForm(forms.Form):
+
+    name = forms.CharField()
+    readonly = forms.BooleanField(required=False)
+    compression = forms.BooleanField(required=False)
+    dedup = forms.BooleanField(required=False)
 
 class CreateDatasetForm(forms.Form):
     name = forms.CharField()

--- a/integral_view/forms/zfs_forms.py
+++ b/integral_view/forms/zfs_forms.py
@@ -1,45 +1,36 @@
 from django import forms
 
 
-class DatasetForm(forms.Form):
+class CommonPropertiesForm(forms.Form):
 
     name = forms.CharField()
     readonly = forms.BooleanField(required=False)
     compression = forms.BooleanField(required=False)
     dedup = forms.BooleanField(required=False)
+
+
+class BaseDatasetForm(CommonPropertiesForm):
+
     quota_size = forms.IntegerField()
     ch = [('G', 'GB'), ('M', 'MB')]
     quota_unit = forms.ChoiceField(choices=ch)
 
-class ZvolForm(forms.Form):
+class BaseZvolForm(CommonPropertiesForm):
 
-    name = forms.CharField()
-    readonly = forms.BooleanField(required=False)
-    compression = forms.BooleanField(required=False)
-    dedup = forms.BooleanField(required=False)
+    pass
 
-class CreateDatasetForm(forms.Form):
-    name = forms.CharField()
-    readonly = forms.BooleanField(required=False)
-    compression = forms.BooleanField(required=False)
-    dedup = forms.BooleanField(required=False)
-    quota_size = forms.IntegerField()
-    ch = [('G', 'GB'), ('M', 'MB')]
-    quota_unit = forms.ChoiceField(choices=ch)
+class CreateDatasetForm(BaseDatasetForm):
+
     pool = forms.CharField()
 
 
-class CreateZvolForm(forms.Form):
-    name = forms.CharField()
-    compression = forms.BooleanField(required=False)
-    dedup = forms.BooleanField(required=False)
+class CreateZvolForm(BaseZvolForm):
+
     thin_provisioned = forms.BooleanField(required=False)
     pool = forms.CharField()
     size = forms.DecimalField(decimal_places=1)
-
     ch = [('8K', '8K'), ('16K', '16K'), ('32K', '32K'), ('64K', '64K')]
     block_size = forms.ChoiceField(choices=ch)
-
     ch = [('GB', 'G'), ('MB', 'M')]
     unit = forms.ChoiceField(choices=ch)
 

--- a/integral_view/templates/view_zfs_pool_datasets_zvols.html
+++ b/integral_view/templates/view_zfs_pool_datasets_zvols.html
@@ -75,9 +75,7 @@
                           <a class="btn btn-default btn-xs dropdown-toggle " data-toggle="dropdown" href="#"> <i class="fa fa-cog fa-fw" ></i>&nbsp;Dataset actions <span class="fa fa-caret-down" title="Toggle dropdown menu"></span> </a>
                           <ul class="dropdown-menu">
                             <li><a class="action-dropdown" href="/view_zfs_dataset?name={{ds.name}}" title="View and configure this dataset"><i class="fa fa-cog fa-fw" ></i>View and configure</a></li>
-                            <!--
-                            <li><a class="action-dropdown" href="/replicate_zfs_dataset?pool_name={{ds.name}}" title="Configure replication for this dataset"><i class="fa fa-copy fa-fw" ></i>Configure replication</a></li>
-                            -->
+                           <!--  <li><a class="action-dropdown" href="/create_remote_replication?pool_name={{ds.name}}" title="Configure replication for this dataset"><i class="fa fa-copy fa-fw" ></i>Configure replication</a></li> -->
                           </ul>
                         </div>
                       </td>
@@ -130,7 +128,7 @@
                           <a class="btn btn-default btn-xs dropdown-toggle " data-toggle="dropdown" href="#"> <i class="fa fa-cog fa-fw" ></i>&nbsp;Volume actions <span class="fa fa-caret-down" title="Toggle dropdown menu"></span> </a>
                           <ul class="dropdown-menu">
                             <li><a class="action-dropdown" href="/view_zfs_zvol?name={{ds.name}}&pool_name={{ds.name}}" title="View and configure this volume"><i class="fa fa-cog fa-fw" ></i>View and configure</a></li>
-                            <li><a class="action-dropdown" href="/replicate_zfs_dataset?pool_name={{ds.name}}" title="Configure replication for this dataset"><i class="fa fa-copy fa-fw" ></i>Configure replication</a></li>
+                            <!-- <li><a class="action-dropdown" href="/create_remote_replication?pool_name={{ds.name}}" title="Configure replication for this dataset"><i class="fa fa-copy fa-fw" ></i>Configure replication</a></li> -->
                           </ul>
                         </div>
                       </td>

--- a/integral_view/templates/view_zfs_zvol.html
+++ b/integral_view/templates/view_zfs_zvol.html
@@ -8,11 +8,11 @@
   <div class="btn-group btn-group-sm pull-right"  >
     <a class="btn btn-default dropdown-toggle" data-toggle="dropdown" href="#"> <i class="fa fa-cog fa-fw" ></i>&nbsp;Actions <span class="fa fa-caret-down" title="Toggle dropdown menu"></span> </a>
     <ul class="dropdown-menu">
-      {% if "disabled" in replication_status %}
+      <!-- {% if "disabled" in replication_status %}
     	  <li><a class="action-dropdown" href="/replicate_zfs_dataset?dataset_name={{name}}"><i class="fa fa-copy fa-fw"></i>&nbsp;Enable async replication</a></li>
       {% else %}
     	  <li><a class="action-dropdown" href="/replicate_zfs_dataset?dataset_name={{name}}"><i class="fa fa-copy fa-fw"></i>&nbsp;Modify/Disable async replication</a></li>
-    	{% endif %}
+    	{% endif %} -->
       <li class="divider"></li>
       <li><a class="action-dropdown" href="/delete_zfs_dataset?name={{name}}&type=zvol&pool_name={{pool}}" style="color:red"> <i class="fa fa-trash fa-fw"></i>&nbsp;Delete this block device volume  </a></li>
       <li class="divider"></li>

--- a/integral_view/views/zfs_management.py
+++ b/integral_view/views/zfs_management.py
@@ -891,12 +891,8 @@ def update_zfs_dataset(request):
         elif not properties:
             raise Exception("Error loading ZFS dataset properties")
 
-        zvol_d, err = zfs.get_all_zvols()
-        if err:
-            raise Exception(err)
-        for zvol in zvol_d:
-            if name in zvol['name']:
-                is_zvol = True
+        if properties['type']['value'] == 'volume':
+            is_zvol = True
 
         return_dict['type'] = properties['type']
         if is_zvol is False:
@@ -914,16 +910,16 @@ def update_zfs_dataset(request):
                 else:
                     initial[p] = True
             if is_zvol is True:
-                form = zfs_forms.ZvolForm(initial=initial)
+                form = zfs_forms.BaseZvolForm(initial=initial)
             else:
-                form = zfs_forms.DatasetForm(initial=initial)
+                form = zfs_forms.BaseDatasetForm(initial=initial)
             return_dict['form'] = form
             return django.shortcuts.render_to_response("update_zfs_dataset.html", return_dict, context_instance=django.template.context.RequestContext(request))
         else:
             if is_zvol is True:
-                form = zfs_forms.ZvolForm(request.POST)
+                form = zfs_forms.BaseZvolForm(request.POST)
             else:
-                form = zfs_forms.DatasetForm(request.POST)
+                form = zfs_forms.BaseDatasetForm(request.POST)
             return_dict['form'] = form
             if not form.is_valid():
                 return django.shortcuts.render_to_response("update_zfs_dataset.html", return_dict, context_instance=django.template.context.RequestContext(request))


### PR DESCRIPTION
### Separate form class for filesystem(dataset) & zvol
Class DatasetForm in zfs_forms.py has quota_size, ch, quota_unit
entires that may not be applicable for zvols now. This change was
brought in by commit 84f17e3f228474b3f62f4db1c3bc8e1c1de39723 to
address issue #183.
- To validate the form for zvols, a new class ZvolForm is added.
- Disables redirection to replication page from view_zfs_pool

addresses #202

### Autoincrement primary keys of select tables
Since sqlite reuses indices that are not currently active or assigned,
it affects tasks that are removed from tasks table but its correspoding
process is active. The reuse of indices causes task logs to be
overwritten since our tasks logs are named by task_id.

addresses #168 #169

Signed-off-by: six-k <ramsri.hp@gmail.com>