### PR TITLE
Update login_menu to pass replicator user

### DIFF
--- a/scripts/shell/login_menu.sh
+++ b/scripts/shell/login_menu.sh
@@ -226,7 +226,7 @@ read_input(){
 }
  
 user_name=`id -un`
-if [[ ("$user_name" != "root") && ("$user_name" != "integralstor") ]]
+if [[ ("$user_name" != "root") && ("$user_name" != "integralstor") && ("$user_name" != "replicator")]]
 then
   trap '' SIGINT SIGQUIT SIGTSTP
   while true


### PR DESCRIPTION
Since replication is done as replicator user, remote logins are
necessary to execute relevant commands on the remote machine. This
allows replicator to pass through the login_menu to get a shell.

Signed-off-by: six-k <ramsri.hp@gmail.com>