### PR TITLE
Feature to enable the superadmin to modify many dataset/zvol properties from the UI.

### DIFF
--- a/integral_view/forms/zfs_forms.py
+++ b/integral_view/forms/zfs_forms.py
@@ -31,12 +31,12 @@ class AdvancedDatasetZvolPropertiesForm(forms.Form):
     property_value = forms.CharField()
 
     def __init__(self, *args, **kwargs):
-        if kwargs and 'modifyable_properties' in kwargs:
-            modifyable_properties = kwargs.pop('modifyable_properties')
+        if kwargs and 'modifiable_properties' in kwargs:
+            modifiable_properties = kwargs.pop('modifiable_properties')
         super(AdvancedDatasetZvolPropertiesForm,
               self).__init__(*args, **kwargs)
         ch = []
-        for property_name, property in modifyable_properties.items():
+        for property_name, property in modifiable_properties.items():
             ch.append((property_name, '%s(%s) - currently %s' %
                        (property['short_desc'], property_name, property['value'])))
         self.fields['property_name'] = forms.ChoiceField(choices=ch)

--- a/integral_view/forms/zfs_forms.py
+++ b/integral_view/forms/zfs_forms.py
@@ -15,13 +15,31 @@ class BaseDatasetForm(CommonPropertiesForm):
     ch = [('G', 'GB'), ('M', 'MB')]
     quota_unit = forms.ChoiceField(choices=ch)
 
+
 class BaseZvolForm(CommonPropertiesForm):
 
     pass
 
+
 class CreateDatasetForm(BaseDatasetForm):
 
     pool = forms.CharField()
+
+
+class AdvancedDatasetZvolPropertiesForm(forms.Form):
+    name = forms.CharField()
+    property_value = forms.CharField()
+
+    def __init__(self, *args, **kwargs):
+        if kwargs and 'modifyable_properties' in kwargs:
+            modifyable_properties = kwargs.pop('modifyable_properties')
+        super(AdvancedDatasetZvolPropertiesForm,
+              self).__init__(*args, **kwargs)
+        ch = []
+        for property_name, property in modifyable_properties.items():
+            ch.append((property_name, '%s(%s) - currently %s' %
+                       (property['short_desc'], property_name, property['value'])))
+        self.fields['property_name'] = forms.ChoiceField(choices=ch)
 
 
 class CreateZvolForm(BaseZvolForm):

--- a/integral_view/templates/update_zfs_dataset_zvol_advanced_properties.html
+++ b/integral_view/templates/update_zfs_dataset_zvol_advanced_properties.html
@@ -1,0 +1,68 @@
+{% extends 'storage_base.html' %}
+
+{%block tab_header %}
+  {%if type.value == 'filesystem' %}
+    Modify ZFS dataset properties - advanced
+  {%elif type.value == 'volume' %}
+    Modify ZFS block device volume properties - advanced
+  {%endif%}
+{%endblock%}
+
+{% block inside_content %}
+
+  <form id="edit_form" name="edit_form" action="" method="post">
+    {%csrf_token%}
+    <input name="name" type="hidden" value="{{ form.name.value }}">
+    <table class="table" style="width:800px">
+      <tr>
+        <th>
+          {%if type.value == 'filesystem' %}
+            Dataset name :
+          {%elif type.value == 'volume' %}
+            Block device volume name :
+          {%endif%}
+        </th>
+        <td> {{ form.name.value }} </td>
+        <td> &nbsp </td>
+      </tr>
+      <tr>
+        <th> Property:</th>
+        <td>
+          <select name="property_name" class="form-control" id="id_property_name">
+            {% for choice in form.property_name.field.choices %}
+              <option value="{{choice.0}}" {%if choice.0 == form.initial.property_name %} selected="selected"{%endif%}>{{choice.1}}</option>
+            {%endfor%}
+          </select>
+        </td>
+        <td> {{ form.property_name.errors }} </td>
+      </tr>
+      <tr>
+        <th> Value:</th>
+        <td>
+          <input type="text"  name="property_value" class="form-control" id="id_name" placeholder="Enter property value" > 
+        </td>
+        <td> {{ form.property_value.errors }} </td>
+      </tr>
+    </table>
+    <div class="btn-group btn-group-sm" role="group" aria-label="...">
+      <a href="/view_zfs_dataset/?name={{form.name.value}}" role="button" class="btn btn-default"> Cancel</a>&nbsp;&nbsp;
+      <button type="submit" class="btn btn-primary">Save</button>
+    </div>
+  </form>
+
+{%endblock%}
+
+{%block help_header%}
+  Update ZFS {%if type.value == 'filesystem' %} dataset {%elif type.value == 'volume' %} block device volume {%endif%} advanced properties
+{%endblock%}
+
+{%block help_body%}
+  <p>Use this screen to update the advanced properties for a particular ZFS {%if type.value == 'filesystem' %} dataset {%elif type.value == 'volume' %} block device volume {%endif%}. The settings will take effect upon saving this information.</p>
+{%endblock%}
+
+{% block tab_active %}
+  <script>
+    make_tab_active("view_zfs_pools_tab")
+  </script>
+{% endblock %}
+

--- a/integral_view/templates/view_zfs_dataset.html
+++ b/integral_view/templates/view_zfs_dataset.html
@@ -11,7 +11,10 @@
     <div class="btn-group btn-group-sm pull-right"  >
       <a class="btn btn-default dropdown-toggle" data-toggle="dropdown" href="#"> <i class="fa fa-cog fa-fw"></i>&nbsp;Actions &nbsp;<span class="fa fa-caret-down" title="Toggle dropdown menu"></span> </a>
       <ul class="dropdown-menu">
-        <li><a href="/update_zfs_dataset?name={{name}}&pool_name={{pool}}" > <i class="fa fa-cog fa-fw"></i>&nbsp;Change {%if properties.type.value == 'filesystem'%} dataset {%elif properties.type.value == 'volume'%} block device volume {%endif%} properties</a> </li>
+        {%if request.user.username == 'superadmin'%} 
+          <li><a href="/update_zfs_dataset?name={{name}}&pool_name={{pool}}" > <i class="fa fa-cog fa-fw"></i>&nbsp;Update {%if properties.type.value == 'filesystem'%} dataset {%elif properties.type.value == 'volume'%} block device volume {%endif%} basic properties</a> </li>
+          <li><a href="/update_zfs_dataset_advanced_properties?name={{name}}" > <i class="fa fa-cog fa-fw"></i>&nbsp;Update {%if properties.type.value == 'filesystem'%} dataset {%elif properties.type.value == 'volume'%} block device volume {%endif%} advanced properties</a> </li>
+        {%endif%}
         {%if properties.type.value == 'filesystem'%}
           <li><a href="/view_dir_ownership_permissions?path={{properties.mountpoint.value}}" > <i class="fa fa-cog fa-fw"></i>&nbsp;Change ownership and permissions</a></li>
         {%endif%}
@@ -47,28 +50,14 @@
         <tr>
           <th> Property name </th>
           <th> Property value </th>
-          <th> Property information </th>
         </tr>
-        {%for pname, p in properties.items %}
-          {%if pname in exposed_properties %}
+        {%for property in ordered_exposed_properties%}
             <tr>
               <td> 
-                {%if pname == 'creation'%} 
-                    Created on 
-                {%elif pname == 'quota'%} 
-                    Space consumption limit
-                {%elif pname == 'usedbychildren'%} 
-                    Space used by children 
-                {%elif pname == 'usedbydataset'%} 
-                    Space used by this dataset 
-                {%else%}{{pname|title}}{%endif%}
+                {{property.prop_dict.short_desc}}({{property.prop_name}})
               </td>
-              <td> {{p.value}}</td>
-              <td> 
-                {%if p.source == 'local' %} Explicitly set {%elif p.source == '-'%} Informational only {%else%}{{p.source|title}}{%endif%}
-              </td>
+              <td> {{property.prop_dict.value}}</td>
             </tr>
-          {%endif%}
         {%endfor%}
       </table>
 

--- a/integral_view/urls.py
+++ b/integral_view/urls.py
@@ -24,7 +24,7 @@ from integral_view.views.local_user_management import view_local_users, create_l
 
 from integral_view.views.nfs_share_management import view_nfs_shares, view_nfs_share, delete_nfs_share, create_nfs_share, update_nfs_share
 
-from integral_view.views.zfs_management import view_zfs_pools, view_zfs_pool, view_zfs_dataset, update_zfs_dataset, delete_zfs_dataset, create_zfs_dataset, view_zfs_snapshots, create_zfs_snapshot, delete_zfs_snapshot, rename_zfs_snapshot, rollback_zfs_snapshot, create_zfs_pool, delete_zfs_pool, update_zfs_slog, delete_zfs_slog, scrub_zfs_pool, create_zfs_zvol, view_zfs_zvol, import_all_zfs_pools, create_zfs_spares, delete_zfs_spare, expand_zfs_pool, delete_zfs_quota, update_zfs_quota, export_zfs_pool, import_zfs_pool, schedule_zfs_snapshot, update_zfs_l2arc, delete_zfs_l2arc, view_zfs_snapshot_schedules
+from integral_view.views.zfs_management import view_zfs_pools, view_zfs_pool, view_zfs_dataset, update_zfs_dataset, delete_zfs_dataset, create_zfs_dataset, view_zfs_snapshots, create_zfs_snapshot, delete_zfs_snapshot, rename_zfs_snapshot, rollback_zfs_snapshot, create_zfs_pool, delete_zfs_pool, update_zfs_slog, delete_zfs_slog, scrub_zfs_pool, create_zfs_zvol, view_zfs_zvol, import_all_zfs_pools, create_zfs_spares, delete_zfs_spare, expand_zfs_pool, delete_zfs_quota, update_zfs_quota, export_zfs_pool, import_zfs_pool, schedule_zfs_snapshot, update_zfs_l2arc, delete_zfs_l2arc, view_zfs_snapshot_schedules, update_zfs_dataset_advanced_properties
 
 from integral_view.views.networking_management import view_interfaces, view_interface, view_bond, update_interface_state, update_interface_address, create_bond, delete_bond, view_hostname, update_hostname, view_dns_nameservers, update_dns_nameservers, delete_vlan, create_vlan
 
@@ -305,6 +305,8 @@ urlpatterns = patterns('',
                            login_required(view_zfs_dataset)),
                        url(r'^update_zfs_dataset/',
                            login_required(update_zfs_dataset)),
+                       url(r'^update_zfs_dataset_advanced_properties/',
+                           login_required(update_zfs_dataset_advanced_properties)),
                        url(r'^delete_zfs_dataset/',
                            login_required(delete_zfs_dataset)),
                        url(r'^create_zfs_dataset/',

--- a/integral_view/views/zfs_management.py
+++ b/integral_view/views/zfs_management.py
@@ -2,7 +2,7 @@ import django
 import django.template
 
 from integralstor_utils import zfs, audit, ramdisk, config, command, db
-from integralstor_utils import cifs as common_cifs
+from integralstor_utils import cifs as common_cifs, django_utils
 from integralstor import nfs, local_users, iscsi_stgt, system_info
 
 from integral_view.forms import zfs_forms
@@ -844,7 +844,9 @@ def view_zfs_dataset(request):
         if err:
             raise Exception(err)
 
+        is_zvol = True
         if properties['type']['value'] == 'filesystem':
+            is_zvol = False
             quotas, err = zfs.get_all_quotas(dataset_name)
             if err:
                 raise Exception(err)
@@ -860,8 +862,11 @@ def view_zfs_dataset(request):
             return_dict['children'] = children
         return_dict['name'] = dataset_name
         return_dict['properties'] = properties
-        return_dict['exposed_properties'] = ['compression', 'compressratio',
-                                             'dedup',  'type', 'usedbychildren', 'usedbydataset', 'creation', 'quota']
+        prop_dict, err = zfs.get_exposed_ds_zvol_properties(properties)
+        if err:
+            raise Exception(err)
+        return_dict['exposed_properties'] = prop_dict['exposed_properties']
+        return_dict['ordered_exposed_properties'] = prop_dict['ordered_exposed_properties']
         if 'result' in request.GET:
             return_dict['result'] = request.GET['result']
 
@@ -884,7 +889,7 @@ def update_zfs_dataset(request):
                 'Dataset name not specified. Please use the menus.')
         name = request.REQUEST["name"]
         is_zvol = False
-        
+
         properties, err = zfs.get_properties(name)
         if not properties and err:
             raise Exception(err)
@@ -948,7 +953,7 @@ def update_zfs_dataset(request):
                             p, changed)
                         audit_str += " property '%s' set to '%s'" % (
                             p, changed)
-                        success = True        
+                        success = True
 
             if is_zvol is False:
                 orig_quota = properties['quota']['value']
@@ -960,6 +965,170 @@ def update_zfs_dataset(request):
                 else:
                     new_quota = '%d%s' % (cd['quota_size'], cd['quota_unit'])
                 print 'new quota is ', new_quota
+                if orig_quota != new_quota:
+                    result, err = zfs.update_property(name, 'quota', new_quota)
+                    if not result:
+                        result_str += ' Error setting property quota'
+                        if not err:
+                            results += ' : %s' % str(e)
+                    audit_str += " property 'quota' set to '%s'" % new_quota
+                    success = True
+            if success:
+                audit.audit("edit_zfs_dataset", audit_str, request)
+
+            return django.http.HttpResponseRedirect('/view_zfs_dataset?name=%s&ack=modified_dataset_properties' % name)
+    except Exception, e:
+        return_dict['base_template'] = "storage_base.html"
+        return_dict["page_title"] = 'Modify ZFS dataset properties'
+        return_dict['tab'] = 'view_zfs_pools_tab'
+        return_dict["error"] = 'Error modifying ZFS dataset properties'
+        return_dict["error_details"] = str(e)
+        return django.shortcuts.render_to_response("logged_in_error.html", return_dict, context_instance=django.template.context.RequestContext(request))
+
+
+def update_zfs_dataset_advanced_properties(request):
+    return_dict = {}
+    try:
+        name, err = django_utils.get_request_parameter_value(request, 'name')
+        if err:
+            raise Exception(err)
+        if not name:
+            raise Exception(
+                'Dataset name not specified. Please use the menus.')
+
+        properties, err = zfs.get_properties(name)
+        if not properties and err:
+            raise Exception(err)
+        elif not properties:
+            raise Exception("Error loading ZFS dataset properties")
+
+        return_dict['type'] = properties['type']
+
+        prop_dict, err = zfs.get_exposed_ds_zvol_properties(properties)
+        if err:
+            raise Exception(err)
+
+        if request.method == "GET":
+            # Return the conf page
+            initial = {}
+            initial['name'] = name
+            form = zfs_forms.AdvancedDatasetZvolPropertiesForm(
+                modifyable_properties=prop_dict['modifyable_properties'], initial=initial)
+            return_dict['form'] = form
+            return django.shortcuts.render_to_response("update_zfs_dataset_zvol_advanced_properties.html", return_dict, context_instance=django.template.context.RequestContext(request))
+        else:
+            form = zfs_forms.AdvancedDatasetZvolPropertiesForm(
+                request.POST, modifyable_properties=prop_dict['modifyable_properties'])
+            return_dict['form'] = form
+            if not form.is_valid():
+                return django.shortcuts.render_to_response("update_zfs_dataset_zvol_advanced_properties.html", return_dict, context_instance=django.template.context.RequestContext(request))
+            cd = form.cleaned_data
+            result_str = ""
+            result, err = zfs.update_property(
+                name, cd['property_name'], cd['property_value'])
+            if err:
+                raise Exception(err)
+            audit_str = "Updated the dataset/volume property %s for dataset %s to %s : " % (
+                cd['property_name'], name, cd['property_value'])
+            audit.audit("edit_zfs_dataset", audit_str, request)
+
+            return django.http.HttpResponseRedirect('/view_zfs_dataset?name=%s&ack=modified_dataset_properties' % name)
+    except Exception, e:
+        return_dict['base_template'] = "storage_base.html"
+        return_dict["page_title"] = 'Modify ZFS advance dataset/volume properties'
+        return_dict['tab'] = 'view_zfs_pools_tab'
+        return_dict["error"] = 'Error modifying ZFS advanced dataset/volume properties'
+        return_dict["error_details"] = str(e)
+        return django.shortcuts.render_to_response("logged_in_error.html", return_dict, context_instance=django.template.context.RequestContext(request))
+
+
+def update_zfs_dataset_properties(request):
+    return_dict = {}
+    try:
+        name, err = django_utils.get_request_parameter_value(request, 'name')
+        if err:
+            raise Exception(err)
+        if not name:
+            raise Exception(
+                'Dataset name not specified. Please use the menus.')
+
+        is_zvol = False
+
+        properties, err = zfs.get_properties(name)
+        if not properties and err:
+            raise Exception(err)
+        elif not properties:
+            raise Exception("Error loading ZFS dataset properties")
+
+        if properties['type']['value'] == 'volume':
+            is_zvol = True
+
+        return_dict['type'] = properties['type']
+        if is_zvol is False:
+            return_dict['quota'] = properties['quota']['value']
+        else:
+            return_dict['quota'] = 'none'
+
+        if request.method == "GET":
+            # Return the conf page
+            initial = {}
+            initial['name'] = name
+            for p in ['compression', 'dedup', 'readonly']:
+                if properties[p]['value'] == 'off':
+                    initial[p] = False
+                else:
+                    initial[p] = True
+            if is_zvol is True:
+                form = zfs_forms.BaseZvolForm(initial=initial)
+            else:
+                form = zfs_forms.BaseDatasetForm(initial=initial)
+            return_dict['form'] = form
+            return django.shortcuts.render_to_response("update_zfs_dataset.html", return_dict, context_instance=django.template.context.RequestContext(request))
+        else:
+            if is_zvol is True:
+                form = zfs_forms.BaseZvolForm(request.POST)
+            else:
+                form = zfs_forms.BaseDatasetForm(request.POST)
+            return_dict['form'] = form
+            if not form.is_valid():
+                return django.shortcuts.render_to_response("update_zfs_dataset.html", return_dict, context_instance=django.template.context.RequestContext(request))
+            cd = form.cleaned_data
+            result_str = ""
+            audit_str = "Changed the following dataset properties for dataset %s : " % name
+            success = False
+            # Do this for all boolean values
+            to_change = []
+            for p in ['compression', 'dedup', 'readonly']:
+                orig = properties[p]['value']
+                if cd[p]:
+                    changed = 'on'
+                else:
+                    changed = 'off'
+                # print 'property %s orig %s changed %s'%(p, orig, changed)
+                if orig != changed:
+                    result, err = zfs.update_property(name, p, changed)
+                    # print err
+                    if not result:
+                        result_str += ' Error setting property %s' % p
+                        if not err:
+                            results += ' : %s' % str(e)
+                    else:
+                        result_str += ' Successfully set property %s to %s' % (
+                            p, changed)
+                        audit_str += " property '%s' set to '%s'" % (
+                            p, changed)
+                        success = True
+
+            if is_zvol is False:
+                orig_quota = properties['quota']['value']
+                # print 'original quota was ', orig_quota
+                if 'quota_size' not in cd or not cd['quota_size']:
+                    new_quota = 'none'
+                elif cd['quota_size'] == 0:
+                    new_quota = 'none'
+                else:
+                    new_quota = '%d%s' % (cd['quota_size'], cd['quota_unit'])
+                # print 'new quota is ', new_quota
                 if orig_quota != new_quota:
                     result, err = zfs.update_property(name, 'quota', new_quota)
                     if not result:

--- a/integral_view/views/zfs_management.py
+++ b/integral_view/views/zfs_management.py
@@ -1015,12 +1015,12 @@ def update_zfs_dataset_advanced_properties(request):
             initial = {}
             initial['name'] = name
             form = zfs_forms.AdvancedDatasetZvolPropertiesForm(
-                modifyable_properties=prop_dict['modifyable_properties'], initial=initial)
+                modifiable_properties=prop_dict['modifiable_properties'], initial=initial)
             return_dict['form'] = form
             return django.shortcuts.render_to_response("update_zfs_dataset_zvol_advanced_properties.html", return_dict, context_instance=django.template.context.RequestContext(request))
         else:
             form = zfs_forms.AdvancedDatasetZvolPropertiesForm(
-                request.POST, modifyable_properties=prop_dict['modifyable_properties'])
+                request.POST, modifiable_properties=prop_dict['modifiable_properties'])
             return_dict['form'] = form
             if not form.is_valid():
                 return django.shortcuts.render_to_response("update_zfs_dataset_zvol_advanced_properties.html", return_dict, context_instance=django.template.context.RequestContext(request))

--- a/integral_view/views/zfs_management.py
+++ b/integral_view/views/zfs_management.py
@@ -989,12 +989,14 @@ def update_zfs_dataset(request):
 def update_zfs_dataset_advanced_properties(request):
     return_dict = {}
     try:
-        name, err = django_utils.get_request_parameter_value(request, 'name')
+        param_dict, err = django_utils.get_request_parameter_values(request, [
+                                                                    'name'])
         if err:
             raise Exception(err)
-        if not name:
+        if 'name' not in param_dict.keys() or not param_dict['name']:
             raise Exception(
                 'Dataset name not specified. Please use the menus.')
+        name = param_dict['name']
 
         properties, err = zfs.get_properties(name)
         if not properties and err:
@@ -1045,12 +1047,14 @@ def update_zfs_dataset_advanced_properties(request):
 def update_zfs_dataset_properties(request):
     return_dict = {}
     try:
-        name, err = django_utils.get_request_parameter_value(request, 'name')
+        param_dict, err = django_utils.get_request_parameter_values(request, [
+                                                                    'name'])
         if err:
             raise Exception(err)
-        if not name:
+        if 'name' not in param_dict.keys() or not param_dict['name']:
             raise Exception(
                 'Dataset name not specified. Please use the menus.')
+        name = param_dict['name']
 
         is_zvol = False
 


### PR DESCRIPTION
Currently, if any advanced properties on a dataset or a zvol need to be set, then they have to be done through the command line. This feature will allow it to be done through the UI. 

Caveats : 
This is only enabled for superadmin and it is assumed that only people who know what they are doing will use this. Since there are many possible options with each having many possible values, I have not put in any error checking on the values. So if zfs accepts the passed value, it will succeed.