### PR TITLE
Prohibit NIC Bond creation & Networking form validation fix

### DIFF
--- a/integral_view/forms/networking_forms.py
+++ b/integral_view/forms/networking_forms.py
@@ -11,16 +11,18 @@ class EditHostnameForm(forms.Form):
 
     def clean(self):
         cd = super(EditHostnameForm, self).clean()
-        hostname = cd['hostname']
-        if '.' in hostname:
-            self._errors["hostname"] = self.error_class(
-                ["Please enter a hostname without the domain name component (no '.'s allowed)"])
-        valid, err = networking.validate_hostname(hostname)
-        if err:
-            self._errors["hostname"] = self.error_class([err])
-        elif not valid:
-            self._errors["hostname"] = self.error_class(
-                ['Invalid hostname. Only alphabets, digits and hyphens permitted.'])
+        hostname = cd.get("hostname")
+        if hostname is not None:
+            if hostname and '.' in hostname:
+                self._errors["hostname"] = self.error_class(
+                    ["Please enter a hostname without the domain name component (no '.'s allowed)"])
+            valid, err = networking.validate_hostname(hostname)
+            if err:
+                self._errors["hostname"] = self.error_class(
+                    ['%s. \tOnly alphabets, digits and hyphens permitted.' % err])
+            elif not valid:
+                self._errors["hostname"] = self.error_class(
+                    ['Invalid hostname. Only alphabets, digits and hyphens permitted.'])
         return cd
 
 
@@ -30,21 +32,22 @@ class DNSNameServersForm(forms.Form):
 
     def clean(self):
         cd = super(DNSNameServersForm, self).clean()
-        nameservers = cd['nameservers']
-        if ',' in nameservers:
-            slist = nameservers.split(',')
-        else:
-            slist = nameservers.split(' ')
-        for server in slist:
-            valid, err = networking.validate_ip(server)
-            if err:
-                self._errors["nameservers"] = self.error_class(
-                    ["Error validating DNS server IP address %s : %s" % (server, err)])
-                break
-            elif not valid:
-                self._errors["nameservers"] = self.error_class(
-                    ["Invalid DNS server IP address : %s" % server])
-                break
+        nameservers = cd.get("nameservers")
+        if nameservers is not None:
+            if nameservers and ',' in nameservers:
+                slist = nameservers.split(',')
+            else:
+                slist = nameservers.split(' ')
+            for server in slist:
+                valid, err = networking.validate_ip(server)
+                if err:
+                    self._errors["nameservers"] = self.error_class(
+                        ["Error validating DNS server IP address %s : %s" % (server, err)])
+                    break
+                elif not valid:
+                    self._errors["nameservers"] = self.error_class(
+                        ["Invalid DNS server IP address : %s" % server])
+                    break
         return cd
 
 
@@ -123,10 +126,12 @@ class CreateBondForm(forms.Form):
 
     def clean(self):
         cd = super(CreateBondForm, self).clean()
-        name = cd['name']
-        if name in self.existing_bonds:
-            self._errors["name"] = self.error_class(
-                ["A bond or interface of this name already exists. Please choose another name."])
+        #name = cd['name']
+        name = cd.get("name")
+        if name is not None:
+            if name and name in self.existing_bonds:
+                self._errors["name"] = self.error_class(
+                    ["A Bond or interface of this name already exists. Please choose another name."])
         return cd
 
 

--- a/integral_view/templates/create_bond.html
+++ b/integral_view/templates/create_bond.html
@@ -8,6 +8,8 @@
 
   <form class="form-horizontal" role="form"name="create_form" action="" method="post">
     {%csrf_token%}
+
+    {% if is_iface_avail == False %} <h5>Atleast one unused Ethernet interface must be available to create an NIC Bond</h5> {% endif %}
     <table  class="table " style="width:800px">
       <tr>
         <th> Bond name: </th>
@@ -42,10 +44,20 @@
 
     <div class="btn-group btn-group-sm" role="group" aria-label="...">
       <a href="/view_interfaces" role="button" class="btn btn-default"> Cancel</a>&nbsp;&nbsp;
-      <button type="submit" class="btn btn-primary cover-page" > Create </button>
+      <button type="submit" id="id_submit" class="btn btn-primary cover-page" > Create </button>
     </div>
   </form>
 
+  <script type="text/javascript">
+    $(document).ready(function(){
+      var is_iface = "{{is_iface_avail}}";
+      if (is_iface == "False"){
+        $("#id_name").attr('disabled','disabled');
+        $("#id_mode").attr('disabled','disabled');
+        $("#id_submit").attr('disabled','disabled');
+      }
+    });
+  </script>
 {%endblock%}
 
 {%block help_header%}

--- a/integral_view/views/common.py
+++ b/integral_view/views/common.py
@@ -8,7 +8,7 @@ import django
 from django.contrib.auth.decorators import login_required
 import django.http
 
-from integralstor_utils import command, audit, alerts, zfs, stats, config
+from integralstor_utils import command, audit, alerts, zfs, stats, config, django_utils
 from integralstor_utils import cifs as cifs_common, services_management
 from integralstor_utils import system_date_time
 
@@ -481,8 +481,13 @@ def show(request, page, info = None):
         return_dict["error"] = str(e)
       else:
         return_dict["log_level_str"] = log_level
-      if "saved" in request.REQUEST:
-        return_dict["saved"] = request.REQUEST["saved"]
+
+      ret, err = django_utils.get_request_parameter_values(request,['saved'])
+      if err:
+        raise Exception(err)
+      if 'saved' not in ret:
+        raise Exception("Request not found, please use the menus.")
+      return_dict["saved"] = ret['saved']
 
     return django.shortcuts.render_to_response(template, return_dict, context_instance=django.template.context.RequestContext(request))
   except Exception, e:

--- a/integral_view/views/local_user_management.py
+++ b/integral_view/views/local_user_management.py
@@ -5,7 +5,7 @@ import django.template
 import integral_view
 from integral_view.forms import local_user_forms
 
-from integralstor_utils import audit
+from integralstor_utils import audit, django_utils
 from integralstor import local_users
 
 
@@ -157,10 +157,15 @@ def update_local_user_group_membership(request):
         t_group_list, err = local_users.get_local_groups()
         if err:
             raise Exception(err)
-        if 'username' not in request.REQUEST:
-            raise Exception("Unknown user specified")
 
-        username = request.REQUEST["username"]
+        req_ret, err = django_utils.get_request_parameter_values(request, [
+                                                                 'username'])
+        if err:
+            raise Exception(err)
+        if 'username' not in req_ret:
+            raise Exception('Invalid request, please use the menus.')
+
+        username = req_ret['username']
         ud, err = local_users.get_local_user(username)
         if err:
             raise Exception(err)
@@ -313,10 +318,14 @@ def create_local_group(request):
 def delete_local_group(request):
     return_dict = {}
     try:
-        if "grpname" not in request.REQUEST:
-            raise Exception("Invalid request. No group name specified.")
+        req_ret, err = django_utils.get_request_parameter_values(request, [
+                                                                 'grpname'])
+        if err:
+            raise Exception(err)
+        if 'grpname' not in req_ret:
+            raise Exception('Invalid request, please use the menus.')
 
-        gd, err = local_users.get_local_group(request.REQUEST['grpname'])
+        gd, err = local_users.get_local_group(req_ret['grpname'])
         if err or (not gd):
             if err:
                 raise Exception(err)
@@ -357,8 +366,12 @@ def delete_local_user(request):
 
     return_dict = {}
     try:
-        if "username" not in request.REQUEST:
-            raise Exception("Invalid request. No user name specified.")
+        req_ret, err = django_utils.get_request_parameter_values(request, [
+                                                                 'username'])
+        if err:
+            raise Exception(err)
+        if 'username' not in req_ret:
+            raise Exception('Invalid request, please use the menus.')
 
         if request.method == "GET":
             # Return the form
@@ -416,8 +429,8 @@ def update_local_user_password(request):
 
                 audit_str = "Changed password for local user %s" % cd["username"]
                 ret, err = audit.audit("change_local_user_password",
-                            audit_str, request)
-                #print ret, err
+                                       audit_str, request)
+                # print ret, err
                 if err:
                     raise Exception(err)
                 return django.http.HttpResponseRedirect('/view_local_users?ack=changed_password')
@@ -440,10 +453,14 @@ def update_group_membership(request):
             if request.GET["ack"] == "created":
                 return_dict['ack_message'] = "Local group successfully created"
 
-        if "grpname" not in request.REQUEST:
-            raise Exception("Invalid request. No group name specified.")
+        req_ret, err = django_utils.get_request_parameter_values(request, [
+                                                                 'grpname'])
+        if err:
+            raise Exception(err)
+        if 'grpname' not in req_ret:
+            raise Exception('Invalid request, please use the menus.')
 
-        gd, err = local_users.get_local_group(request.REQUEST['grpname'])
+        gd, err = local_users.get_local_group(req_ret['grpname'])
         if err or (not gd):
             if err:
                 raise Exception(err)
@@ -534,10 +551,13 @@ def edit_local_user_gid(request):
     group_list,err = local_users.get_local_groups()
     if err:
       raise Exception(err)
-    if 'username' not in request.REQUEST:
-      raise Exception("Unknown user specified")
+    req_ret, err = django_utils.get_request_parameter_values(request,['username'])
+    if err:
+        raise Exception(err)
+    if 'username' not in req_ret:
+        raise Exception('Invalid request, please use the menus.')
 
-    username = request.REQUEST["username"]
+    username = req_ret['username']
     ud,err = local_users.get_local_user(username)
     if err:
       raise Exception(err)

--- a/integral_view/views/log_management.py
+++ b/integral_view/views/log_management.py
@@ -8,7 +8,7 @@ from django.contrib import auth
 from django.core.files.storage import default_storage
 from django.contrib.auth.decorators import login_required
 
-from integralstor_utils import config, audit, alerts, db
+from integralstor_utils import config, audit, alerts, db, django_utils
 
 import integral_view
 from integral_view.forms import log_management_forms, common_forms
@@ -426,11 +426,14 @@ def raise_alert(request):
 
   return_dict = {}
   template = "logged_in_error.html"
-  if "msg" not in request.REQUEST:
+  req_ret, err = django_utils.get_request_parameter_values(request,['msg'])
+  if err:
+    raise Exception(err)
+  if 'msg' not in req_ret:
     return_dict["error"] = "No alert message specified."
   else:
     try:
-      msg = request.REQUEST["msg"]
+      msg = req_ret['msg']
       ret, err = alerts.raise_alert(msg)
       if err:
         raise Exception(err)

--- a/integral_view/views/networking_management.py
+++ b/integral_view/views/networking_management.py
@@ -353,36 +353,35 @@ def create_bond(request):
                 "Error loading network interface information : No interfaces found")
 
         bm, err = networking.get_bonding_masters()
-        print 'bm: ', bm
         if err:
             raise Exception(err)
         bid, err = networking.get_bonding_info_all()
-        print 'bid: ', bid
         if err:
             raise Exception(err)
 
         return_dict['interfaces'] = interfaces
-        if_list = []
+        iface_list = []
         existing_bonds = []
         for if_name, iface in interfaces.items():
-            #ret, err = networking.get_ip_info (if_name)
-            # if ret:
-                # continue
             if if_name.startswith('lo') or if_name in bid['by_slave']:
                 continue
             if if_name in bm:
                 existing_bonds.append(if_name)
                 continue
-            if_list.append(if_name)
+            iface_list.append(if_name)
+
+        return_dict['is_iface_avail'] = False
+        if iface_list:
+            return_dict['is_iface_avail'] = True
 
         if request.method == "GET":
             form = networking_forms.CreateBondForm(
-                interfaces=if_list, existing_bonds=existing_bonds)
+                interfaces=iface_list, existing_bonds=existing_bonds)
             return_dict['form'] = form
             return django.shortcuts.render_to_response("create_bond.html", return_dict, context_instance=django.template.context.RequestContext(request))
         else:
             form = networking_forms.CreateBondForm(
-                request.POST, interfaces=if_list, existing_bonds=existing_bonds)
+                request.POST, interfaces=iface_list, existing_bonds=existing_bonds)
             return_dict['form'] = form
             if not form.is_valid():
                 return django.shortcuts.render_to_response("create_bond.html", return_dict, context_instance=django.template.context.RequestContext(request))

--- a/integral_view/views/networking_management.py
+++ b/integral_view/views/networking_management.py
@@ -1,7 +1,7 @@
 import django
 import django.template
 
-from integralstor_utils import networking, audit, command, config, unicode_utils
+from integralstor_utils import networking, audit, command, config, unicode_utils, django_utils
 from django.contrib.auth.decorators import login_required
 
 import socket
@@ -53,11 +53,14 @@ def view_interface(request):
     return_dict = {}
     try:
         template = 'logged_in_error.html'
-        if 'name' not in request.REQUEST:
-            raise Exception(
-                "Error loading network interface information : No interface name specified.")
+        req_ret, err = django_utils.get_request_parameter_values(request, [
+                                                                 'name'])
+        if err:
+            raise Exception(err)
+        if 'name' not in req_ret:
+            raise Exception('Invalid request, please use the menus')
 
-        name = request.REQUEST['name']
+        name = req_ret['name']
         interfaces, err = networking.get_interfaces()
         if err:
             raise Exception(err)
@@ -97,16 +100,16 @@ def update_interface_state(request):
 
     return_dict = {}
     try:
-        if 'name' not in request.REQUEST:
-            raise Exception(
-                "No interface name specified. Please use the menus")
+        req_ret, err = django_utils.get_request_parameter_values(
+            request, ['name', 'state'])
+        if err:
+            raise Exception(err)
+        if ('name' and 'state') not in req_ret:
+            raise Exception('Invalid request, please use the menus')
 
-        if 'state' not in request.REQUEST:
-            raise Exception("No state specified. Please use the menus")
-
-        name = request.REQUEST["name"]
+        name = req_ret['name']
         return_dict["name"] = name
-        state = request.REQUEST["state"]
+        state = req_ret['state']
         return_dict["state"] = state
 
         if request.method == "GET" and state == 'down':
@@ -137,10 +140,14 @@ def view_bond(request):
     return_dict = {}
     try:
         template = 'logged_in_error.html'
-        if 'name' not in request.REQUEST:
-            raise Exception("No bond name specified.")
+        req_ret, err = django_utils.get_request_parameter_values(request, [
+                                                                 'name'])
+        if err:
+            raise Exception(err)
+        if 'name' not in req_ret:
+            raise Exception('Invalid request, please use the menus')
 
-        name = request.REQUEST['name']
+        name = req_ret['name']
 
         interfaces, err = networking.get_interfaces()
         if err:
@@ -172,11 +179,14 @@ def view_bond(request):
 def update_interface_address(request):
     return_dict = {}
     try:
-        if 'name' not in request.REQUEST:
-            raise Exception(
-                "Interface name not specified. Please use the menus.")
+        req_ret, err = django_utils.get_request_parameter_values(request, [
+                                                                 'name'])
+        if err:
+            raise Exception(err)
+        if 'name' not in req_ret:
+            raise Exception('Invalid request, please use the menus')
 
-        name = request.REQUEST["name"]
+        name = req_ret['name']
         interfaces, err = networking.get_interfaces()
         if err:
             raise Exception(err)
@@ -243,10 +253,12 @@ def update_interface_address(request):
 def create_vlan(request):
     return_dict = {}
     try:
-
-        if 'nic' not in request.REQUEST:
-            raise Exception(
-                'No base network interface specified. Please use the menus.')
+        req_ret, err = django_utils.get_request_parameter_values(request, [
+                                                                 'nic'])
+        if err:
+            raise Exception(err)
+        if 'nic' not in req_ret:
+            raise Exception('Invalid request, please use the menus')
 
         interfaces, err = networking.get_interfaces()
         if err:
@@ -269,7 +281,7 @@ def create_vlan(request):
                     existing_vlans.append(int(comps[1]))
         if request.method == "GET":
             form = networking_forms.CreateVLANForm(existing_vlans=existing_vlans, initial={
-                                                   'base_interface': request.REQUEST['nic']})
+                                                   'base_interface': req_ret['nic']})
             return_dict['form'] = form
             return django.shortcuts.render_to_response("create_vlan.html", return_dict, context_instance=django.template.context.RequestContext(request))
         else:
@@ -308,10 +320,13 @@ def create_vlan(request):
 def delete_vlan(request):
     return_dict = {}
     try:
-        if 'name' not in request.REQUEST:
-            raise Exception("No VLAN name specified. Please use the menus")
-
-        name = request.REQUEST["name"]
+        req_ret, err = django_utils.get_request_parameter_values(request, [
+                                                                 'name'])
+        if err:
+            raise Exception(err)
+        if 'name' not in req_ret:
+            raise Exception('Invalid request, please use the menus')
+        name = req_ret['name']
         return_dict["name"] = name
 
         if request.method == "GET":
@@ -431,10 +446,13 @@ def delete_bond(request):
 
     return_dict = {}
     try:
-        if 'name' not in request.REQUEST:
-            raise Exception("No bond name specified. Please use the menus")
-
-        name = request.REQUEST["name"]
+        req_ret, err = django_utils.get_request_parameter_values(request, [
+                                                                 'name'])
+        if err:
+            raise Exception(err)
+        if 'name' not in req_ret:
+            raise Exception('Invalid request, please use the menus')
+        name = req_ret['name']
         return_dict["name"] = name
 
         if request.method == "GET":

--- a/integral_view/views/nfs_share_management.py
+++ b/integral_view/views/nfs_share_management.py
@@ -1,7 +1,7 @@
 import django
 import django.template
 
-from integralstor_utils import zfs, audit
+from integralstor_utils import zfs, audit, django_utils
 from integralstor import nfs
 
 import integral_view
@@ -169,13 +169,17 @@ def create_nfs_share(request):
             raise Exception(
                 'No ZFS datasets available. Please create a dataset before creating shares.')
 
-        if 'dataset' in request.REQUEST:
-            dataset = request.REQUEST['dataset']
+        req_ret, err = django_utils.get_request_parameter_values(
+            request, ['dataset', 'path'])
+        if err:
+            raise Exception(err)
+
+        if 'dataset' in req_ret:
+            dataset = req_ret['dataset']
         else:
             dataset = ds_list[0]['mountpoint']
-
-        if 'path' in request.REQUEST:
-            path = request.REQUEST['path']
+        if 'path' in req_ret:
+            dataset = req_ret['path']
         else:
             path = dataset
 

--- a/integral_view/views/ntp_management.py
+++ b/integral_view/views/ntp_management.py
@@ -6,7 +6,7 @@ from django.http import HttpResponse
 
 import shutil
 
-from integralstor_utils import ntp, services_management
+from integralstor_utils import ntp, services_management, django_utils
 from integralstor import system_info
 
 import integral_view
@@ -22,11 +22,16 @@ def view_ntp_settings(request):
         if err:
             raise Exception(err)
         return_dict["ntp_servers"] = ntp_servers
-        if "ack" in request.REQUEST and request.REQUEST['ack'] == 'saved':
+
+        req_ret, err = django_utils.get_request_parameter_values(
+            request, ['ack', 'server_used'])
+        if err:
+            raise Exception(err)
+        if 'ack' in req_ret and req_ret['ack'] == 'saved':
             return_dict["ack_message"] = 'NTP settings have successfully been updated.'
-        elif "ack" in request.REQUEST and request.REQUEST['ack'] == 'ntp_synced':
-            if 'server_used' in request.REQUEST:
-                return_dict["ack_message"] = 'One time ntp sync with server %s successfully completed.' % request.REQUEST['server_used']
+        elif 'ack' in req_ret and req_ret['ack'] == 'ntp_synced':
+            if 'server_used' in req_ret:
+                return_dict["ack_message"] = 'One time ntp sync with server %s successfully completed.' % req_ret['server_used']
         return django.shortcuts.render_to_response('view_ntp_settings.html', return_dict, context_instance=django.template.context.RequestContext(request))
     except Exception, e:
         return_dict['base_template'] = "services_base.html"

--- a/integral_view/views/pki_management.py
+++ b/integral_view/views/pki_management.py
@@ -1,7 +1,7 @@
 import django
 import django.template
 
-from integralstor_utils import audit, pki
+from integralstor_utils import audit, pki, django_utils
 from integral_view.forms import pki_forms
 
 import os
@@ -36,10 +36,12 @@ def delete_ssl_certificate(request):
 
     return_dict = {}
     try:
-        if 'name' not in request.REQUEST:
-            raise Exception(
-                "No certificate name specified. Please use the menus")
-        name = request.REQUEST["name"]
+        ret, err = django_utils.get_request_parameter_values(request, ['name'])
+        if err:
+            raise Exception(err)
+        if 'name' not in ret:
+            raise Exception("Invalid request, please use the menus.")
+        name = ret['name']
         return_dict["name"] = name
 
         if request.method == "GET":

--- a/integral_view/views/remote_replication_management.py
+++ b/integral_view/views/remote_replication_management.py
@@ -1,7 +1,7 @@
 import django
 import django.template
 
-from integralstor_utils import zfs, audit, config, remote_replication, scheduler_utils
+from integralstor_utils import zfs, audit, config, remote_replication, scheduler_utils, django_utils
 
 
 def view_remote_replications(request):
@@ -103,9 +103,14 @@ def update_remote_replication(request):
     return_dict = {}
     try:
 
-        if 'remote_replication_id' not in request.REQUEST:
-            raise Exception('Invalid request. Please use the menus.')
-        remote_replication_id = request.REQUEST['remote_replication_id']
+        ret, err = django_utils.get_request_parameter_values(
+            request, ['remote_replication_id'])
+        if err:
+            raise Exception(err)
+        if 'remote_replication_id' not in ret:
+            raise Exception(
+                "Requested remote replication not found, please use the menus.")
+        remote_replication_id = ret['remote_replication_id']
         replications, err = remote_replication.get_remote_replications(
             remote_replication_id)
         if err:
@@ -166,9 +171,14 @@ def update_remote_replication(request):
 def delete_remote_replication(request):
     return_dict = {}
     try:
-        if 'remote_replication_id' not in request.REQUEST:
-            raise Exception('Invalid request. Please use the menus.')
-        remote_replication_id = request.REQUEST['remote_replication_id']
+        ret, err = django_utils.get_request_parameter_values(
+            request, ['remote_replication_id'])
+        if err:
+            raise Exception(err)
+        if 'remote_replication_id' not in ret:
+            raise Exception(
+                "Requested remote replication not found, please use the menus.")
+        remote_replication_id = ret['remote_replication_id']
         return_dict['remote_replication_id'] = remote_replication_id
         replications, err = remote_replication.get_remote_replications(
             remote_replication_id)
@@ -182,9 +192,16 @@ def delete_remote_replication(request):
             return_dict['replication'] = replications[0]
             return django.shortcuts.render_to_response("delete_zfs_replication_conf.html", return_dict, context_instance=django.template.context.RequestContext(request))
         else:
+            ret, err = django_utils.get_request_parameter_values(
+                request, ['cron_task_id'])
+            if err:
+                raise Exception(err)
+            if 'cron_task_id' not in ret:
+                raise Exception("Request not found, please use the menus.")
+            cron_task_id = ret['cron_task_id']
 
             cron_remove, err = scheduler_utils.delete_cron(
-                int(request.REQUEST['cron_task_id']))
+                int(cron_task_id))
             if err:
                 raise Exception(err)
 

--- a/integral_view/views/scheduler_cron_management.py
+++ b/integral_view/views/scheduler_cron_management.py
@@ -6,7 +6,7 @@ import django.http
 import os
 import os.path
 
-from integralstor_utils import scheduler_utils, config, command, audit
+from integralstor_utils import scheduler_utils, config, command, audit, django_utils
 
 
 def view_background_tasks(request):
@@ -32,14 +32,18 @@ def view_background_tasks(request):
 def delete_background_task(request):
     return_dict = {}
     try:
-        if 'task_id' not in request.REQUEST:
+        req_ret, err = django_utils.get_request_parameter_values(request, [
+                                                                 'task_id'])
+        if err:
+            raise Exception(err)
+        if 'task_id' not in req_ret:
             raise Exception('Invalid request. Please use the menus.')
 
-        task, err = scheduler_utils.get_task(request.REQUEST['task_id'])
+        task, err = scheduler_utils.get_task(req_ret['task_id'])
         if err:
             raise Exception(err)
 
-        ret, err = scheduler_utils.delete_task(request.REQUEST['task_id'])
+        ret, err = scheduler_utils.delete_task(req_ret['task_id'])
         if err:
             raise Exception(err)
 

--- a/integral_view/views/stgt_iscsi_management.py
+++ b/integral_view/views/stgt_iscsi_management.py
@@ -1,5 +1,5 @@
 
-from integralstor_utils import audit, zfs
+from integralstor_utils import audit, zfs, django_utils
 from integralstor import iscsi_stgt
 
 from integral_view.forms import iscsi_stgt_forms
@@ -118,11 +118,15 @@ def create_iscsi_target(request):
 def delete_iscsi_target(request):
     return_dict = {}
     try:
-        if 'target_name' not in request.REQUEST:
+        req_ret, err = django_utils.get_request_parameter_values(request, [
+                                                                 'target_name'])
+        if err:
+            raise Exception(err)
+        if 'target_name' not in req_ret:
             raise Exception(
-                "Malformed request. No target specified. Please use the menus.")
+                "Invalid request, please use the menus.")
 
-        target_name = request.REQUEST['target_name']
+        target_name = req_ret['target_name']
 
         if request.method == "GET":
             return_dict["target_name"] = target_name
@@ -150,10 +154,15 @@ def delete_iscsi_target(request):
 def create_iscsi_lun(request):
     return_dict = {}
     try:
-        if 'target_name' not in request.REQUEST:
+        req_ret, err = django_utils.get_request_parameter_values(request, [
+                                                                 'target_name'])
+        if err:
+            raise Exception(err)
+        if 'target_name' not in req_ret:
             raise Exception(
-                "Malformed request. No target specified. Please use the menus.")
-        target_name = request.REQUEST['target_name']
+                "Invalid request, please use the menus.")
+
+        target_name = req_ret['target_name']
         zvols, err = zfs.get_all_zvols()
         if err:
             raise Exception(err)
@@ -199,15 +208,16 @@ def create_iscsi_lun(request):
 def delete_iscsi_lun(request):
     return_dict = {}
     try:
-        if 'target_name' not in request.REQUEST:
+        req_ret, err = django_utils.get_request_parameter_values(
+            request, ['target_name', 'store'])
+        if err:
+            raise Exception(err)
+        if ('target_name' and 'store') not in req_ret:
             raise Exception(
-                "Malformed request. No target specified. Please use the menus.")
-        if 'store' not in request.REQUEST:
-            raise Exception(
-                "Malformed request. No LUN specified. Please use the menus.")
+                "Invalid request, please use the menus.")
 
-        store = request.REQUEST['store']
-        target_name = request.REQUEST['target_name']
+        store = req_ret['store']
+        target_name = req_ret['target_name']
 
         if request.method == "GET":
             return_dict["target_name"] = target_name
@@ -237,15 +247,16 @@ def delete_iscsi_lun(request):
 def create_iscsi_user_authentication(request):
     return_dict = {}
     try:
-        if 'authentication_type' not in request.REQUEST:
+        req_ret, err = django_utils.get_request_parameter_values(
+            request, ['target_name', 'authentication_type'])
+        if err:
+            raise Exception(err)
+        if ('target_name' and 'authentication_type') not in req_ret:
             raise Exception(
-                "Malformed request. No user type specified. Please use the menus.")
-        if 'target_name' not in request.REQUEST:
-            raise Exception(
-                "Malformed request. No target specified. Please use the menus.")
+                "Invalid request, please use the menus.")
 
-        authentication_type = request.REQUEST['authentication_type']
-        target_name = request.REQUEST['target_name']
+        authentication_type = req_ret['authentication_type']
+        target_name = req_ret['target_name']
 
         if authentication_type not in ['incoming', 'outgoing']:
             raise Exception("Invalid user type. Please use the menus.")
@@ -297,19 +308,17 @@ def create_iscsi_user_authentication(request):
 def delete_iscsi_user_authentication(request):
     return_dict = {}
     try:
-        if 'authentication_type' not in request.REQUEST:
+        req_ret, err = django_utils.get_request_parameter_values(
+            request, ['target_name', 'authentication_type', 'username'])
+        if err:
+            raise Exception(err)
+        if ('target_name' and 'authentication_type' and 'username') not in req_ret:
             raise Exception(
-                "Malformed request. No user type specified. Please use the menus.")
-        if 'target_name' not in request.REQUEST:
-            raise Exception(
-                "Malformed request. No target namespecified. Please use the menus.")
-        if 'username' not in request.REQUEST:
-            raise Exception(
-                "Malformed request. No user name specified. Please use the menus.")
+                "Invalid request, please use the menus.")
 
-        authentication_type = request.REQUEST['authentication_type']
-        target_name = request.REQUEST['target_name']
-        username = request.REQUEST['username']
+        authentication_type = req_ret['authentication_type']
+        target_name = req_ret['target_name']
+        username = req_ret['username']
 
         if authentication_type not in ['incoming', 'outgoing']:
             raise Exception("Invalid user type. Please use the menus.")
@@ -350,11 +359,16 @@ def delete_iscsi_user_authentication(request):
 def create_iscsi_acl(request):
     return_dict = {}
     try:
-        if 'target_name' not in request.REQUEST:
+        req_ret, err = django_utils.get_request_parameter_values(request, [
+                                                                 'target_name'])
+        if err:
+            raise Exception(err)
+        if 'target_name' not in req_ret:
             raise Exception(
-                "Malformed request. No target specified. Please use the menus.")
+                "Invalid request, please use the menus.")
 
-        target_name = request.REQUEST['target_name']
+        target_name = req_ret['target_name']
+
         target, err = iscsi_stgt.get_target(target_name)
         if err:
             raise Exception(err)
@@ -400,15 +414,16 @@ def create_iscsi_acl(request):
 def delete_iscsi_acl(request):
     return_dict = {}
     try:
-        if 'acl' not in request.REQUEST:
+        req_ret, err = django_utils.get_request_parameter_values(
+            request, ['target_name', 'acl'])
+        if err:
+            raise Exception(err)
+        if ('target_name' and 'acl') not in req_ret:
             raise Exception(
-                "Malformed request. No ACL specified. Please use the menus.")
-        if 'target_name' not in request.REQUEST:
-            raise Exception(
-                "Malformed request. No target specified. Please use the menus.")
+                "Invalid request, please use the menus.")
 
-        acl = request.REQUEST['acl']
-        target_name = request.REQUEST['target_name']
+        target_name = req_ret['target_name']
+        acl = req_ret['acl']
 
         if request.method == "GET":
             return_dict["target_name"] = target_name

--- a/integral_view/views/zfs_management.py
+++ b/integral_view/views/zfs_management.py
@@ -72,8 +72,12 @@ def view_zfs_pool(request):
     return_dict = {}
     try:
         template = 'logged_in_error.html'
-        if 'name' not in request.REQUEST:
-            raise Exception("No pool specified.")
+        req_ret, err = django_utils.get_request_parameter_values(request, [
+                                                                 'view', 'name'])
+        if err:
+            raise Exception(err)
+        if 'name' not in req_ret:
+            raise Exception("Invalid request, please use the menus.")
 
         if "ack" in request.GET:
             if request.GET["ack"] == "saved":
@@ -108,12 +112,12 @@ def view_zfs_pool(request):
                 return_dict['ack_message'] = "Successfully added spare disks to the pool"
             elif request.GET["ack"] == "removed_spare":
                 return_dict['ack_message'] = "Successfully removed a spare disk from the pool"
-        if 'view' in request.REQUEST:
-            view = request.REQUEST['view']
+        if 'view' in req_ret:
+            view = req_ret['view']
         else:
             view = 'basic'
 
-        pool_name = request.REQUEST['name']
+        pool_name = req_ret['name']
         pool, err = zfs.get_pool(pool_name)
 
         if err:
@@ -169,12 +173,16 @@ def view_zfs_pool(request):
 def update_zfs_quota(request):
     return_dict = {}
     try:
-        if 'path' not in request.REQUEST or 'ug_type' not in request.REQUEST or 'path_type' not in request.REQUEST:
+        req_ret, err = django_utils.get_request_parameter_values(
+            request, ['path', 'path_type', 'ug_type', 'pool_name'])
+        if err:
+            raise Exception(err)
+        if ('path' and 'path_type' and 'pool_name' and 'ug_type') not in req_ret:
             raise Exception("Malformed request. Please use the menus")
-        path_type = request.REQUEST["path_type"]
-        path = request.REQUEST["path"]
-        ug_type = request.REQUEST["ug_type"]
-        pool_name = request.REQUEST["pool_name"]
+        path_type = req_ret['path_type']
+        path = req_ret['path']
+        ug_type = req_ret['ug_type']
+        pool_name = req_ret['pool_name']
         if ug_type not in ['user', 'group']:
             raise Exception("Malformed request. Please use the menus")
         if ug_type == 'user':
@@ -231,13 +239,17 @@ def update_zfs_quota(request):
 def delete_zfs_quota(request):
     return_dict = {}
     try:
-        if 'path' not in request.REQUEST or 'ug_name' not in request.REQUEST or 'ug_type' not in request.REQUEST or 'path_type' not in request.REQUEST:
+        req_ret, err = django_utils.get_request_parameter_values(
+            request, ['path', 'path_type', 'ug_type', 'ug_name', 'pool_name'])
+        if err:
+            raise Exception(err)
+        if ('path' and 'path_type' and 'ug_name' and 'ug_type' and 'pool_name') not in req_ret:
             raise Exception("Malformed request. Please use the menus")
-        path = request.REQUEST["path"]
-        path_type = request.REQUEST["path_type"]
-        pool_name = request.REQUEST["pool_name"]
-        ug_name = request.REQUEST["ug_name"]
-        ug_type = request.REQUEST["ug_type"]
+        path_type = req_ret['path_type']
+        path = req_ret['path']
+        ug_type = req_ret['ug_type']
+        ug_name = req_ret['ug_type']
+        pool_name = req_ret['pool_name']
 
         return_dict["path"] = path
         return_dict["pool_name"] = pool_name
@@ -278,9 +290,13 @@ def delete_zfs_quota(request):
 def export_zfs_pool(request):
     return_dict = {}
     try:
-        if 'pool_name' not in request.REQUEST:
-            raise Exception("Malformed request. Please use the menus")
-        pool_name = request.REQUEST["pool_name"]
+        req_ret, err = django_utils.get_request_parameter_values(request, [
+                                                                 'pool_name'])
+        if err:
+            raise Exception(err)
+        if 'pool_name' not in req_ret:
+            raise Exception("Invalid request, please use the menus.")
+        pool_name = req_ret['pool_name']
 
         return_dict["pool_name"] = pool_name
         if request.method == "GET":
@@ -436,9 +452,13 @@ def create_zfs_pool(request):
 def expand_zfs_pool(request):
     return_dict = {}
     try:
-        if 'pool_name' not in request.REQUEST:
-            raise Exception('Pool not specified. Please use the menus.')
-        pool_name = request.REQUEST['pool_name']
+        req_ret, err = django_utils.get_request_parameter_values(request, [
+                                                                 'pool_name'])
+        if err:
+            raise Exception(err)
+        if 'pool_name' not in req_ret:
+            raise Exception("Invalid request, please use the menus.")
+        pool_name = req_ret['pool_name']
         if request.method == 'GET':
             (can_expand, new_pool_type), err = zfs.can_expand_pool(pool_name)
             if err:
@@ -469,9 +489,13 @@ def scrub_zfs_pool(request):
 
     return_dict = {}
     try:
-        if 'name' not in request.REQUEST:
-            raise Exception("No pool specified. Please use the menus")
-        name = request.REQUEST["name"]
+        req_ret, err = django_utils.get_request_parameter_values(request, [
+                                                                 'name'])
+        if err:
+            raise Exception(err)
+        if 'name' not in req_ret:
+            raise Exception("Invalid request, please use the menus.")
+        name = req_ret['name']
         return_dict["name"] = name
         if request.method == "GET":
             # Return the conf page
@@ -500,9 +524,13 @@ def delete_zfs_pool(request):
 
     return_dict = {}
     try:
-        if 'name' not in request.REQUEST:
-            raise Exception("No pool specified. Please use the menus")
-        name = request.REQUEST["name"]
+        req_ret, err = django_utils.get_request_parameter_values(request, [
+                                                                 'name'])
+        if err:
+            raise Exception(err)
+        if 'name' not in req_ret:
+            raise Exception("Invalid request, please use the menus.")
+        name = req_ret['name']
         nfs_shares, err = nfs.get_shares_on_subpath('%s/' % name)
         if err:
             raise Exception(err)
@@ -565,10 +593,13 @@ def update_zfs_slog(request):
 
         template = 'logged_in_error.html'
 
-        if 'pool' not in request.REQUEST:
-            raise Exception("No pool specified.")
-
-        pool_name = request.REQUEST["pool"]
+        req_ret, err = django_utils.get_request_parameter_values(request, [
+                                                                 'pool'])
+        if err:
+            raise Exception(err)
+        if 'pool' not in req_ret:
+            raise Exception("Invalid request, please use the menus.")
+        pool_name = req_ret['pool']
 
         pool, err = zfs.get_pool(pool_name)
 
@@ -672,14 +703,16 @@ def delete_zfs_slog(request):
 
     return_dict = {}
     try:
-        if 'pool' not in request.REQUEST:
-            raise Exception("No pool specified. Please use the menus")
-        if 'device' not in request.REQUEST:
-            raise Exception("No device specified. Please use the menus")
-        pool = request.REQUEST["pool"]
+        req_ret, err = django_utils.get_request_parameter_values(
+            request, ['pool', 'device', 'type'])
+        if err:
+            raise Exception(err)
+        if ('pool' and 'device' and 'type') not in req_ret:
+            raise Exception("Invalid request, please use the menus.")
+        pool = req_ret['pool']
+        device = req_ret['device']
         return_dict["pool"] = pool
-        device = request.REQUEST["device"]
-        type = request.REQUEST["type"]
+        type = req_ret["type"]
         return_dict["device"] = device
         return_dict["type"] = type
         if request.method == "GET":
@@ -714,10 +747,13 @@ def update_zfs_l2arc(request):
     return_dict = {}
     try:
 
-        if 'pool' not in request.REQUEST:
-            raise Exception("No pool specified.")
-
-        pool_name = request.REQUEST["pool"]
+        req_ret, err = django_utils.get_request_parameter_values(request, [
+                                                                 'pool'])
+        if err:
+            raise Exception(err)
+        if 'pool' not in req_ret:
+            raise Exception("Invalid request, please use the menus.")
+        pool_name = req_ret['pool']
 
         pool, err = zfs.get_pool(pool_name)
 
@@ -771,16 +807,16 @@ def delete_zfs_l2arc(request):
     return_dict = {}
     try:
 
-        if 'pool' not in request.REQUEST:
-            raise Exception("No pool specified. Please use the menus")
+        req_ret, err = django_utils.get_request_parameter_values(
+            request, ['pool', 'device'])
+        if err:
+            raise Exception(err)
+        if ('pool' and 'device') not in req_ret:
+            raise Exception("Invalid request, please use the menus.")
+        pool = req_ret['pool']
+        device = req_ret['device']
 
-        if 'device' not in request.REQUEST:
-            raise Exception("No device specified. Please use the menus")
-
-        pool = request.REQUEST["pool"]
         return_dict["pool"] = pool
-
-        device = request.REQUEST["device"]
         return_dict["device"] = device
 
         if request.method == "GET":
@@ -811,8 +847,12 @@ def view_zfs_dataset(request):
     try:
         template = 'logged_in_error.html'
 
-        if 'name' not in request.REQUEST:
-            raise Exception("Malformed request. Please use the menus.")
+        req_ret, err = django_utils.get_request_parameter_values(request, [
+                                                                 'name'])
+        if err:
+            raise Exception(err)
+        if 'name' not in req_ret:
+            raise Exception("Invalid request, please use the menus.")
 
         if "ack" in request.GET:
             if request.GET["ack"] == "set_quota":
@@ -826,7 +866,7 @@ def view_zfs_dataset(request):
             elif request.GET["ack"] == "created_dataset":
                 return_dict['ack_message'] = "ZFS dataset successfully created"
 
-        dataset_name = request.REQUEST['name']
+        dataset_name = req_ret['name']
         if '/' in dataset_name:
             pos = dataset_name.find('/')
             pool = dataset_name[:pos]
@@ -884,10 +924,14 @@ def view_zfs_dataset(request):
 def update_zfs_dataset(request):
     return_dict = {}
     try:
-        if 'name' not in request.REQUEST:
-            raise Exception(
-                'Dataset name not specified. Please use the menus.')
-        name = request.REQUEST["name"]
+        req_ret, err = django_utils.get_request_parameter_values(request, [
+                                                                 'name'])
+        if err:
+            raise Exception(err)
+        if 'name' not in req_ret:
+            raise Exception("Invalid request, please use the menus.")
+
+        name = req_ret['name']
         is_zvol = False
 
         properties, err = zfs.get_properties(name)
@@ -1050,15 +1094,19 @@ def delete_zfs_dataset(request):
 
     return_dict = {}
     try:
-        if 'name' not in request.REQUEST:
-            raise Exception(
-                "Error deleting ZFS dataset- No dataset specified. Please use the menus")
-        if 'type' not in request.REQUEST:
+        req_ret, err = django_utils.get_request_parameter_values(
+            request, ['name', 'type', 'pool_name'])
+        if err:
+            raise Exception(err)
+        if ('name' and 'pool_name') not in req_ret:
+            raise Exception("Invalid request, please use the menus.")
+
+        name = req_ret['name']
+        pool_name = req_ret['pool_name']
+        if 'type' not in req_ret:
             type = 'filesystem'
         else:
-            type = request.REQUEST['type']
-        name = request.REQUEST["name"]
-        pool_name = request.REQUEST["pool_name"]
+            type = req_ret['type']
         nfs_shares, err = nfs.get_shares_on_subpath('%s/' % name)
         if err:
             raise Exception(err)
@@ -1121,9 +1169,14 @@ def delete_zfs_dataset(request):
 def create_zfs_dataset(request):
     return_dict = {}
     try:
-        if 'pool' not in request.REQUEST:
-            raise Exception("No parent pool provided. Please use the menus.")
-        pool = request.REQUEST['pool']
+        req_ret, err = django_utils.get_request_parameter_values(request, [
+                                                                 'pool'])
+        if err:
+            raise Exception(err)
+        if 'pool' not in req_ret:
+            raise Exception("Invalid request, please use the menus.")
+        pool = req_ret['pool']
+
         datasets, err = zfs.get_children_datasets(pool)
         if err:
             raise Exception("Could not retrieve the list of existing datasets")
@@ -1176,9 +1229,14 @@ def create_zfs_dataset(request):
 def create_zfs_zvol(request):
     return_dict = {}
     try:
-        if 'pool' not in request.REQUEST:
-            raise Exception("No parent pool provided. Please use the menus.")
-        pool = request.REQUEST['pool']
+        req_ret, err = django_utils.get_request_parameter_values(request, [
+                                                                 'pool'])
+        if err:
+            raise Exception(err)
+        if 'pool' not in req_ret:
+            raise Exception("Invalid request, please use the menus.")
+        pool = req_ret['pool']
+
         return_dict['pool'] = pool
 
         if request.method == "GET":
@@ -1235,10 +1293,14 @@ def view_zfs_zvol(request):
     return_dict = {}
     try:
         template = 'logged_in_error.html'
-        if 'name' not in request.REQUEST:
-            raise Exception("No block device volume specified.")
+        req_ret, err = django_utils.get_request_parameter_values(request, [
+                                                                 'name'])
+        if err:
+            raise Exception(err)
+        if 'name' not in req_ret:
+            raise Exception("Invalid request, please use the menus.")
+        name = req_ret['name']
 
-        name = request.REQUEST['name']
         if '/' in name:
             pos = name.find('/')
             pool = name[:pos]
@@ -1372,12 +1434,16 @@ def delete_zfs_snapshot(request):
 
     return_dict = {}
     try:
-        if 'name' not in request.REQUEST:
-            raise Exception("No snapshot name specified. Please use the menus")
-        name = request.REQUEST["name"]
-        if 'display_name' in request.REQUEST:
-            return_dict["display_name"] = request.REQUEST['display_name']
+        req_ret, err = django_utils.get_request_parameter_values(
+            request, ['name', 'display_name'])
+        if err:
+            raise Exception(err)
+        if 'name' not in req_ret:
+            raise Exception("Invalid request, please use the menus.")
+        name = req_ret['name']
         return_dict["name"] = name
+        if 'display_name' in req_ret:
+            return_dict["display_name"] = req_ret['display_name']
 
         if request.method == "GET":
             # Return the conf page
@@ -1406,12 +1472,16 @@ def rollback_zfs_snapshot(request):
 
     return_dict = {}
     try:
-        if 'name' not in request.REQUEST:
-            raise Exceptio("No snapshot name specified. Please use the menus")
-        name = request.REQUEST["name"]
-        if 'display_name' in request.REQUEST:
-            return_dict["display_name"] = request.REQUEST['display_name']
+        req_ret, err = django_utils.get_request_parameter_values(
+            request, ['name', 'display_name'])
+        if err:
+            raise Exception(err)
+        if 'name' not in req_ret:
+            raise Exception("Invalid request, please use the menus.")
+        name = req_ret['name']
         return_dict["name"] = name
+        if 'display_name' in req_ret:
+            return_dict["display_name"] = req_ret['display_name']
 
         if request.method == "GET":
             # Return the conf page
@@ -1566,9 +1636,13 @@ def schedule_zfs_snapshot(request):
 def create_zfs_spares(request):
     return_dict = {}
     try:
-        if 'pool_name' not in request.REQUEST:
-            raise Exception('No pool specified. Please use the menus')
-        pool_name = request.REQUEST['pool_name']
+        req_ret, err = django_utils.get_request_parameter_values(request, [
+                                                                 'pool_name'])
+        if err:
+            raise Exception(err)
+        if 'pool_name' not in req_ret:
+            raise Exception("Invalid request, please use the menus.")
+        pool_name = req_ret['pool_name']
         free_drives, err = zfs.get_free_disks_for_spares(pool_name)
         if err:
             raise Exception(err)
@@ -1610,9 +1684,13 @@ def create_zfs_spares(request):
 def delete_zfs_spare(request):
     return_dict = {}
     try:
-        if 'pool_name' not in request.REQUEST:
-            raise Exception('No pool specified. Please use the menus')
-        pool_name = request.REQUEST['pool_name']
+        req_ret, err = django_utils.get_request_parameter_values(request, [
+                                                                 'pool_name'])
+        if err:
+            raise Exception(err)
+        if 'pool_name' not in req_ret:
+            raise Exception("Invalid request, please use the menus.")
+        pool_name = req_ret['pool_name']
         spares, err = zfs.get_pool_spares(pool_name)
         if err:
             raise Exception(err)


### PR DESCRIPTION
Allow NIC Bond creation only if atleast a single Ethernet interface is
available.

Addresses #229

Signed-off-by: six-k <ramsri.hp@gmail.com>

Networking form validation fix

Calling form.is_valid() calls clean() in turn. Our overridden clean()
will remove fields from cleaned_data of those fields that failed
Field Validation. This caused few of our required fields to be removed
from cleaned_data since they were invalid; for instance, if no value
is passed to a required field and that field is referenced in the
overridden clean() function.

Check if the field actually exists in cleaned_data before referencing.

Addresses #228

Signed-off-by: six-k <ramsri.hp@gmail.com>