### PR TITLE
IP configuration status for systemd

### DIFF
--- a/integral_view/templates/view_interfaces.html
+++ b/integral_view/templates/view_interfaces.html
@@ -40,7 +40,7 @@
                 {%endif%}
               </td>
               <td>
-                {% if 'AF_INET' in d.addresses  or d.bootproto == 'dhcp'%}
+                {% if 'AF_INET' in d.addresses  or d.bootproto == 'dhcp' or d.addresses.is_sysd_ip4 == True%}
                   Yes
                 {%else%}
                   No


### PR DESCRIPTION
netifaces from python may not be able to read systemd connection status
at times, so, fetch from nmcli output.

Signed-off-by: six-k <ramsri.hp@gmail.com>