### PR TITLE
fix USB mountpoint

### DIFF
--- a/scripts/shell/usb-mount.sh
+++ b/scripts/shell/usb-mount.sh
@@ -42,7 +42,7 @@ do_mount()
         LABEL+="-${DEVBASE}"
     fi
     DEV_LABEL="${LABEL}"
-    MOUNT_POINT="/media/${LABEL}"
+    MOUNT_POINT="/media/${DEVBASE}_${LABEL}"
 
     echo "Mount point: ${MOUNT_POINT}"
 


### PR DESCRIPTION
Mounts at /media/ by the device base name suffixed with device
label

Signed-off-by: six-k <ramsri.hp@gmail.com>