### PR TITLE
Cascade remote replication task deletions

### DIFF
--- a/config/db/schemas
+++ b/config/db/schemas
@@ -111,13 +111,13 @@ CREATE TABLE "cron_tasks" (
   "description" varchar(200) NOT NULL,
   "command" varchar(200) NOT NULL
 );
+INSERT INTO cron_tasks (cron_task_id, description, command) values (-1, 'Dummy entry for temporary reference', 'echo');
 
 
 CREATE TABLE "remote_replications" (
   "remote_replication_id" integer NOT NULL PRIMARY KEY AUTOINCREMENT,
   "mode" varchar(20) NOT NULL,
-  "cron_task_id" integer NOT NULL,
-  FOREIGN KEY(cron_task_id) REFERENCES cron_tasks(cron_task_id)
+  "cron_task_id" integer NOT NULL REFERENCES cron_tasks(cron_task_id) ON DELETE CASCADE
 );
 
 
@@ -127,8 +127,7 @@ CREATE TABLE "zfs_replications" (
   "target_pool" varchar(100) NOT NULL,
   "target_ip" varchar(30) NOT NULL,
   "target_user_name" varchar(100) NOT NULL,
-  "remote_replication_id" integer NOT NULL,
-  FOREIGN KEY(remote_replication_id) REFERENCES remote_replications(remote_replication_id)
+  "remote_replication_id" integer NOT NULL REFERENCES remote_replications(remote_replication_id) ON DELETE CASCADE
 );
 
 
@@ -141,8 +140,7 @@ CREATE TABLE "rsync_replications" (
   "target_path" varchar(200) NOT NULL,
   "target_ip" varchar(30) NOT NULL,
   "target_user_name" varchar(100) NOT NULL,
-  "remote_replication_id" integer NOT NULL,
-  FOREIGN KEY(remote_replication_id) REFERENCES remote_replications(remote_replication_id)
+  "remote_replication_id" integer NOT NULL REFERENCES remote_replications(remote_replication_id) ON DELETE CASCADE
 );
 
 

--- a/integral_view/views/remote_replication_management.py
+++ b/integral_view/views/remote_replication_management.py
@@ -2,11 +2,11 @@ import ast
 import django
 import django.template
 
-from integralstor_utils import zfs, audit, config, scheduler_utils, django_utils, rsync
-from integralstor import remote_replication
+
+from integralstor_utils import zfs, config, scheduler_utils, django_utils
+from integralstor import audit, rsync, remote_replication
 
 from integral_view.forms import remote_replication_forms
-
 
 def view_remote_replications(request):
     return_dict = {}
@@ -382,8 +382,8 @@ def update_remote_replication(request):
             description += replications[0]['description']
 
             # update the schedule of the cron entry in-place
-            is_update, err = scheduler_utils.update_cron_schedule(
-                cron_task_id, 'root', schedule[0], schedule[1], schedule[2], schedule[3], schedule[4])
+            is_update, err = remote_replication.update_remote_replication_schedule(
+                remote_replication_id, schedule)
             if err:
                 raise Exception(err)
 

--- a/site-packages/integralstor/remote_replication.py
+++ b/site-packages/integralstor/remote_replication.py
@@ -102,7 +102,7 @@ def add_remote_replication(mode, entries):
                 cron_task_id = ids['cron_task_id']
 
         if (not remote_replication_id) or (not cron_task_id):
-            raise Exception('remote_replication_id or cron_task_id is missing')
+            raise Exception('remote_replication_id or cron_task_id is unavailable')
 
     except Exception, e:
         return None, 'Error adding a remote replication task: %s' % e
@@ -165,15 +165,16 @@ def _add_rsync_remote_replication(remote_replication_id, entries):
             raise Exception(err)
 
         # Update cron_task_id which was previously set as -1
-        is_update, err = update_remote_replication(
-            remote_replication_id, cron_task_id)
+        cmd = "update remote_replications set cron_task_id='%d' where remote_replication_id='%s'" % (
+            cron_task_id, remote_replication_id)
+        rowid, err = db.execute_iud(db_path, [[cmd], ], get_rowid=True)
         if err:
             raise Exception(
                 'Scheduling remote replication unsuccessfull: %s' % err)
 
         if (not rsync_remote_replication_id) or (not cron_task_id):
             raise Exception(
-                'rsync_remote_replication_id or cron_task_id is missing')
+                'rsync_remote_replication_id or cron_task_id is unavailable')
 
     except Exception, e:
         return None, 'Error adding rsync remote replication task: %s' % e
@@ -236,15 +237,16 @@ def _add_zfs_remote_replication(remote_replication_id, entries):
             raise Exception(err)
 
         # Update cron_task_id which was previously set as -1
-        is_update, err = update_remote_replication(
-            remote_replication_id, cron_task_id)
+        cmd = "update remote_replications set cron_task_id='%d' where remote_replication_id='%s'" % (
+            cron_task_id, remote_replication_id)
+        rowid, err = db.execute_iud(db_path, [[cmd], ], get_rowid=True)
         if err:
             raise Exception(
                 'Scheduling remote replication unsuccessfull: %s' % err)
 
         if (not zfs_remote_replication_id) or (not cron_task_id):
             raise Exception(
-                'zfs_remote_replication_id or cron_task_id is missing')
+                'zfs_remote_replication_id or cron_task_id is unavailable')
 
     except Exception, e:
         return None, 'Error adding zfs remote replication task: %s' % e
@@ -252,18 +254,34 @@ def _add_zfs_remote_replication(remote_replication_id, entries):
         return {'zfs_remote_replication_id': zfs_remote_replication_id, 'cron_task_id': cron_task_id}, None
 
 
-def update_remote_replication(remote_replication_id, new_cron_task_id):
+def update_remote_replication_schedule(remote_replication_id, schedule):
     try:
+        if not (remote_replication_id and schedule):
+            raise Exception('Invalid arguments')
+
         db_path, err = config.get_db_path()
         if err:
             raise Exception(err)
-        cmd = "update remote_replications set cron_task_id='%d' where remote_replication_id='%s'" % (
-            new_cron_task_id, remote_replication_id)
-        rowid, err = db.execute_iud(db_path, [[cmd], ], get_rowid=True)
+        replications, err = get_remote_replications(
+            remote_replication_id)
         if err:
             raise Exception(err)
+        if not replications:
+            raise Exception('Specified replication definition not found')
+
+        cron_task_id = None
+        if 'cron_task_id' in replications[0]:
+            cron_task_id = replications[0]['cron_task_id']
+        else:
+            raise Exception('Cron task ID unavailable')
+
+        is_update, err = scheduler_utils.update_cron_schedule(
+            cron_task_id, 'root', schedule[0], schedule[1], schedule[2], schedule[3], schedule[4])
+        if err:
+            raise Exception(err)
+
     except Exception, e:
-        return False, 'Error updating  remote replication task : %s' % e
+        return False, 'Error updating remote replication schedule: %s' % e
     else:
         return True, None
 
@@ -289,6 +307,9 @@ def delete_remote_replication(remote_replication_id):
         if err:
             raise Exception(err)
 
+        # Uncomment the following block if 'ON DELETE CASCADE' switch
+        # is removed from the replication related tables in the DB
+        """
         # Reverting a delete is not possible. If this fails, we will
         # end up with dangling entries. Better to remove from
         # remote_replications table first because they used for display
@@ -313,9 +334,10 @@ def delete_remote_replication(remote_replication_id):
                 db_path, [[rsync_cmd], ], get_rowid=False)
             if err:
                 raise Exception(err)
+        """
 
     except Exception, e:
-        return False, 'Error deleting remote replication task : %s' % e
+        return False, 'Error deleting remote replication task: %s' % e
     else:
         return True, None
 


### PR DESCRIPTION
Let sqlite handle cascading deletes of all referenced tables of remote
replication atomically.

Signed-off-by: six-k <ramsri.hp@gmail.com>