### PR TITLE
sync snapshots for rsync replication

### DIFF
--- a/config/db/schemas
+++ b/config/db/schemas
@@ -127,6 +127,7 @@ CREATE TABLE "rsync_replications" (
   "source_path" varchar(200) NOT NULL,
   "target_path" varchar(200) NOT NULL,
   "target_ip" varchar(30) NOT NULL,
+  "is_between_integralstor" boolean DEFAULT 'False',
   "target_user_name" varchar(100) NOT NULL,
   "remote_replication_id" integer NOT NULL REFERENCES remote_replications(remote_replication_id) ON DELETE CASCADE
 );

--- a/integral_view/forms/remote_replication_forms.py
+++ b/integral_view/forms/remote_replication_forms.py
@@ -22,6 +22,8 @@ class RsyncMode(forms.Form):
     remote_path = forms.CharField()
     rsync_type = forms.ChoiceField(choices=[('push', 'local host to remote host(push)'), (
         'pull', 'remote host to local host(pull)'), ('local', 'within the local host')])
+    is_between_integralstor = forms.BooleanField(widget=forms.CheckboxInput(attrs={'checked' : 'checked'}), required=False)
+    # is_between_integralstor = forms.BooleanField(required=False)
 
     def __init__(self, *args, **kwargs):
         switches = None

--- a/integral_view/forms/zfs_forms.py
+++ b/integral_view/forms/zfs_forms.py
@@ -240,6 +240,13 @@ class CreateSnapshotForm(forms.Form):
                 ch.append(tup)
         self.fields['target'] = forms.ChoiceField(choices=ch)
 
+    def clean_name(self):
+        name = self.cleaned_data['name']
+        if name and name.lower().startswith(('rrr_', 'zrr_')):
+            self._errors["name"] = self.error_class(
+                ["Can't start with 'rrr_' or 'zrr_', please try some other name"])
+        return name
+
 
 class ViewSnapshotsForm(forms.Form):
 
@@ -281,6 +288,14 @@ class RenameSnapshotForm(forms.Form):
     ds_name = forms.CharField(widget=forms.HiddenInput)
     snapshot_name = forms.CharField(widget=forms.HiddenInput)
     new_snapshot_name = forms.CharField()
+
+
+    def clean_new_snapshot_name(self):
+        new_snapshot_name = self.cleaned_data['new_snapshot_name']
+        if new_snapshot_name and new_snapshot_name.lower().startswith(('rrr_', 'zrr_')):
+            self._errors["new_snapshot_name"] = self.error_class(
+                ["Can't start with 'rrr_' or 'zrr_', please try some other name"])
+        return new_snapshot_name
 
 
 class DeleteSnapshotsForm(forms.Form):

--- a/integral_view/templates/create_remote_replication.html
+++ b/integral_view/templates/create_remote_replication.html
@@ -123,6 +123,14 @@
 	<td> {{ form.target_ip.errors }} </td>
       </tr>
 
+      {% if form.select_mode.value == "rsync" %}
+      <tr>
+       <th> Is it between IntegralSTOR units? </th>
+        <td> {{ form.is_between_integralstor }} </td>
+        <td> {{ form.is_between_integralstor.errors }} </td>
+      </tr>
+      {% endif %}
+
       {% if form.select_mode.value == "zfs" %}
       <tr>
 	<th> Target IntegralSTOR pool name<sup class="required" /></th>
@@ -135,8 +143,8 @@
 	</td>
 	<td> {{ form.target_pool.errors }} </td>
       </tr>
-
       {% endif %}
+
     </table>
 
     {% if form.select_mode.value == "rsync" %}

--- a/integral_view/templates/update_remote_replication.html
+++ b/integral_view/templates/update_remote_replication.html
@@ -100,6 +100,17 @@
 		  </td>
 		</tr>
 		{% endif %}
+
+		<tr>
+                  <th> Between IntegralSTOR units? </th>
+                  <td>
+                    {% if replication.rsync.0.is_between_integralstor == 'True' %}
+                    Yes
+                    {% else %}
+                    No
+                    {% endif %}
+                  </td>
+		</tr>
         {%endif%}
 
         <tr>

--- a/integral_view/views/remote_replication_management.py
+++ b/integral_view/views/remote_replication_management.py
@@ -259,9 +259,15 @@ def _create_rsync_remote_replication(request, cleaned_data):
         target_path = None
         target_ip = cd['target_ip']
         target_user_name = "replicator"
-        switches_formed = None
+        switches_formed = {}
+        switches_formed['short'] = ''
+        switches_formed['long'] = ''
         switches = {}
         description = ''
+        is_between_integralstor = False
+
+        if 'is_between_integralstor' in cd and cd['is_between_integralstor'] == True:
+            is_between_integralstor = True
 
         rsync_type = cd['rsync_type']
         if rsync_type == 'push':
@@ -293,7 +299,6 @@ def _create_rsync_remote_replication(request, cleaned_data):
                     if v['is_arg']:
                         v['arg_value'] = cd['%s_arg' % v['id']]
                 switches.update(s)
-
         if switches:
             # pass the switches dictionary to form the switch part of
             # the rsync command as a string. Two strings will be
@@ -328,7 +333,7 @@ def _create_rsync_remote_replication(request, cleaned_data):
         # python script as a crontab entry that runs rsync replication.
 
         ids, err = remote_replication.add_remote_replication('rsync', {'rsync_type': rsync_type, 'short_switches': switches_formed['short'], 'long_switches': switches_formed[
-                                                             'long'], 'source_path': source_path, 'target_path': target_path, 'target_ip': target_ip, 'target_user_name': target_user_name, 'description': description, 'schedule': schedule})
+                                                             'long'], 'source_path': source_path, 'target_path': target_path, 'target_ip': target_ip, 'is_between_integralstor': is_between_integralstor, 'target_user_name': target_user_name, 'description': description, 'schedule': schedule})
         if err:
             raise Exception(err)
 

--- a/scripts/python/run_rsync_remote_replication.py
+++ b/scripts/python/run_rsync_remote_replication.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python
 import sys
 from integralstor import remote_replication
-# from datetime import datetime
 
 
 def run_rsync_remote_replication(remote_replication_id):
@@ -10,16 +9,16 @@ def run_rsync_remote_replication(remote_replication_id):
             remote_replication_id)
         if err:
             raise Exception('Could not fetch replication details: %s' % err)
+
         replication = rr[0]
         mode = replication['mode']
-
-        if mode == 'rsync':
-            ret, err = remote_replication.run_rsync_remote_replication(
-                remote_replication_id)
-            if err:
-                raise Exception(err)
-        else:
+        if mode != 'rsync':
             raise Exception('Invalid replication mode')
+
+        ret, err = remote_replication.run_rsync_remote_replication(
+            remote_replication_id)
+        if err:
+            raise Exception(err)
 
     except Exception, e:
         return False, 'Error adding rsync remote replication task: %s' % e

--- a/scripts/shell/rsync_replicator.sh
+++ b/scripts/shell/rsync_replicator.sh
@@ -1,9 +1,11 @@
 # set -o xtrace
-cmd=$1
-# echo $cmd
+rsync_cmd=$1
+rename_snap=$2
+create_snap=$3
+# echo $rsync_cmd
 exit_code=""
 
-echo "$cmd" | /bin/bash
+echo "$rsync_cmd" | /bin/bash
 rsync_rc=$?
 
 echo "Return code from rsync: $rsync_rc"
@@ -13,6 +15,22 @@ if (( "$rsync_rc"=="23" || "$rsync_rc"=="24" || "$rsync_rc"=="25" )); then
   exit_code=0
 else
   exit_code=$rsync_rc
+fi
+
+rename_snap_rc=''
+create_snap_rc=''
+if (( "$exit_code"=="0" )); then
+  echo "Syncing snapshots between the source and target."
+  echo "$rename_snap" | /bin/bash
+  rename_snap_rc=$?
+  echo "$create_snap" | /bin/bash
+  create_snap_rc=$?
+
+  if (( "$rename_snap_rc"=="0" && "$create_snap_rc"=="0" )); then
+    echo "Synced snapshots"
+  else
+    echo "Could not sync snapshots"
+  fi
 fi
 
 exit $exit_code

--- a/scripts/shell/zfs_replicator.sh
+++ b/scripts/shell/zfs_replicator.sh
@@ -17,8 +17,8 @@ secondary_last=""
 secondary_last_snapshot=""
 
 get_primary_snapshot () {
-  primary_last=$(sudo zfs list -t snapshot -o name -s creation | grep $source | grep zfs_remote_repl | tail -1)
-  primary_initial=$(sudo zfs list -t snapshot -o name -s creation | grep $source | grep zfs_remote_repl | head -1)
+  primary_last=$(sudo zfs list -t snapshot -o name -s creation | grep $source | grep zrr_ | tail -1)
+  primary_initial=$(sudo zfs list -t snapshot -o name -s creation | grep $source | grep zrr_ | head -1)
 
   #Get the snapshot names. The Hack. Needs a better code.
   IFS=’@’ read -a primary_initial_snapshot <<< "${primary_initial}"
@@ -30,7 +30,7 @@ get_secondary_snapshot () {
 
   #Last successful snapshot from destination server
   # Sort by creation date so that you always get the latest snapshot by date and not name
-  secondary_last=$(ssh -o ServerAliveInterval=300 -o ServerAliveCountMax=3 $user@$ip "sudo zfs list -t snapshot -o name -s creation | grep $destination/$source_dataset | grep zfs_remote_repl | tail -1")
+  secondary_last=$(ssh -o ServerAliveInterval=300 -o ServerAliveCountMax=3 $user@$ip "sudo zfs list -t snapshot -o name -s creation | grep $destination/$source_dataset | grep zrr_ | tail -1")
   IFS=’@’ read -a secondary_last_snapshot <<< "${secondary_last}"
   if [[ -z "${secondary_last_snapshot[1]}" ]]; then
     echo "No remote replication snapshots found on the destination."

--- a/site-packages/integralstor/remote_replication.py
+++ b/site-packages/integralstor/remote_replication.py
@@ -1,5 +1,5 @@
-from integralstor_utils import db, config, scheduler_utils
-from integralstor import audit
+from integralstor_utils import db, config, scheduler_utils, command
+from integralstor import audit, rsync, datetime_utils
 
 
 def _replication_modes():
@@ -37,6 +37,222 @@ def get_replication_modes():
         return None, str(e)
     else:
         return modes, None
+
+
+def get_snapshot_sync_cmd_post_rsync(remote_replication_id, source_snap_name):
+    """Generate the commands to run on the host machines to sync ZFS
+    snapshots post rsync replication run.
+
+    Rename the temporary snapshot on the source node, create a snapshot
+    by the same name on the target node.
+
+    args:       remote_replication_id,
+                source_snap_name # a string with just the snap name
+                                 # without FS prefix
+    returns:    a dict with two string fields:
+                    rename_snap_cmd # to rename on the source host
+                    create_snap_cmd # to create on the target host
+    """
+    try:
+        rr, err = get_remote_replications(remote_replication_id)
+        if err:
+            raise Exception('Could not fetch replication details: %s' % err)
+
+        replication = rr[0]
+        rsync_entries = replication['rsync'][0]
+        rsync_type = rsync_entries['rsync_type']
+        mode = replication['mode']
+        if mode != 'rsync':
+            raise Exception('Invalid replication mode')
+        is_between_integralstor = rsync_entries['is_between_integralstor']
+        rsync_type = rsync_entries['rsync_type']
+        remote_ip = rsync_entries['target_ip']
+        remote_user_name = rsync_entries['target_user_name']
+        ssh_cmd = 'ssh %s@%s' % (remote_user_name, remote_ip)
+
+        fs_names, err = get_source_target_fs_names(remote_replication_id)
+        if err:
+            raise Exception('Could not get filesystem names: %s' % err)
+        source_fs = fs_names['source_fs']
+        target_fs = fs_names['target_fs']
+        new_snap_name = source_snap_name.split('_tmp')
+
+        source_snap_old_name = '%s@%s' % (source_fs, source_snap_name)
+        source_snap_new_name = '%s@%s' % (source_fs, new_snap_name[0])
+        target_snap_new_name = '%s@%s' % (target_fs, new_snap_name[0])
+        rename_snap = 'sudo zfs rename %s %s' % (
+            source_snap_old_name, source_snap_new_name)
+        create_snap = 'sudo zfs snapshot %s' % target_snap_new_name
+        rename_snap_cmd = ''
+        create_snap_cmd = ''
+
+        if rsync_type == 'pull':
+            create_snap_cmd = '%s' % (create_snap)
+            rename_snap_cmd = '%s \\"%s\\"' % (ssh_cmd, rename_snap)
+            # If the source is not an integralstor unit, digress from
+            # snapshotting
+            if is_between_integralstor == 'False':
+                rename_snap_cmd = ''
+        elif rsync_type == 'push':
+            rename_snap_cmd = '%s' % (rename_snap)
+            create_snap_cmd = '%s \\"%s\\"' % (ssh_cmd, create_snap)
+            # If the target is not an integralstor unit, digress from
+            # snapshotting
+            if is_between_integralstor == 'False':
+                create_snap_cmd = ''
+        elif rsync_type == 'local':
+            rename_snap_cmd = '%s' % (rename_snap)
+            create_snap_cmd = ''
+
+    except Exception, e:
+        return None, str(e)
+    else:
+        return {'rename_snap_cmd': rename_snap_cmd, 'create_snap_cmd': create_snap_cmd}, None
+
+
+def sync_snapshot_prior_rsync(remote_replication_id):
+    """Syncs ZFS snapshot between the hosts involved in the rsync
+    replication prior to the actual data transfer
+
+    Every rsync replication moves data from a snapshot, not the live
+    filesystem. When called prior to the replication run, this function
+    will create a temporary snapshot specific to this replication id on
+    the source. If a temporary snapshot already exists, it will not
+    create a new snapshot. 
+
+    The rsync shell script which runs the actual replication does the
+    snapshot sync post replication run. On a successful run, the
+    temporary snapshot is renamed on the source side. So, if there's a
+    temporary snapshot present, it's safe to assume that the previous
+    run for this replication id did not complete successfully.
+
+    args:       remote_replication_id
+    returns:    a string containing the temporary snapshot name for 
+                the source.
+                pattern:      A_B_C_tmp
+                    where, A: 'rrr_' for rsync remote repl.
+                           B: remote_replication_id
+                           C: datetime_utils str_format='%Y%m%d%H%M'
+    """
+    source_snap_name = None
+    try:
+        run_as_user_name = 'replicator'
+        now_local_epoch, err = datetime_utils.get_epoch(when='now')
+        if err:
+            raise Exception(err)
+        now_local_str, err = datetime_utils.convert_from_epoch(
+            now_local_epoch, return_format='str', str_format='%Y%m%d%H%M', to='local')
+        if err:
+            raise Exception(err)
+
+        rr, err = get_remote_replications(remote_replication_id)
+        if err:
+            raise Exception('Could not fetch replication details: %s' % err)
+
+        replication = rr[0]
+        rsync_entries = replication['rsync'][0]
+        rsync_type = rsync_entries['rsync_type']
+        mode = replication['mode']
+        if mode != 'rsync':
+            raise Exception('Invalid replication mode')
+
+        is_between_integralstor = rsync_entries['is_between_integralstor']
+        rsync_type = rsync_entries['rsync_type']
+        remote_ip = rsync_entries['target_ip']
+        remote_user_name = rsync_entries['target_user_name']
+        ssh_cmd = 'ssh -l replicator -i /home/replicator/.ssh/id_rsa -o ServerAliveInterval=300 -o ServerAliveCountMax=3 %s@%s' % (
+            remote_user_name, remote_ip)
+        # ssh_cmd = 'ssh %s@%s' % (remote_user_name, remote_ip)
+
+        fs_names, err = get_source_target_fs_names(remote_replication_id)
+        if err:
+            raise Exception('Could not get filesystem names: %s' % err)
+        source_fs = fs_names['source_fs']
+        # 'rrr' identifies rsync remote replication
+        new_snap_name = 'rrr_%s_%s_tmp' % (
+            remote_replication_id, now_local_str)
+        new_snap_full_name = '%s@%s' % (source_fs, new_snap_name)
+        get_snap = 'sudo zfs list -H -r %s -t snapshot -o name | grep -e .*@rrr_%s_[0-9]*_tmp$' % (
+            source_fs, remote_replication_id)
+        create_snap = 'sudo zfs snapshot %s' % new_snap_full_name
+        get_snap_cmd = ''
+        create_snap_cmd = ''
+
+        if rsync_type == 'pull':
+            get_snap_cmd = "%s '%s'" % (ssh_cmd, get_snap)
+            create_snap_cmd = "%s '%s'" % (ssh_cmd, create_snap)
+            # If the source is not an integralstor unit, digress from
+            # snapshotting
+            if is_between_integralstor == 'False':
+                get_snap_cmd = create_snap_cmd = None
+        elif rsync_type in ['push', 'local']:
+            get_snap_cmd = '%s' % (get_snap)
+            create_snap_cmd = '%s' % (create_snap)
+
+        if get_snap_cmd and create_snap_cmd:
+            ret, err = command.get_command_output(
+                get_snap_cmd, True, True, run_as_user_name)
+            # If any snap is returned, do not create a new snapshot,
+            # proceed with the existing one since the previous
+            # replication attempt is not complete yet. Else, create a
+            # a new snapshot to seed this attempt
+            if ret and not err:
+                split_name = ret[0].split('@')
+                source_snap_name = split_name[1]
+            else:
+                ret1, err1 = command.get_command_output(
+                    create_snap_cmd, True, True, run_as_user_name)
+                if err1:
+                    raise Exception(err1)
+                source_snap_name = new_snap_name
+
+    except Exception, e:
+        return None, str(e)
+    else:
+        return source_snap_name, None
+
+
+def get_source_target_fs_names(remote_replication_id):
+    """Returns the ZFS file system names of source and target hosts
+    involved in the replication. 
+
+    args:       remote_replication_id
+    returns:    a dict with 'source_fs' & 'target_fs' fields
+                    source_fs & target_fs are strings of the form
+                    POOL_NAME/FS_NAME or POOL_NAME if it's the root
+                    file system 
+    """
+    try:
+        source_fs = None
+        target_fs = None
+        rr, err = get_remote_replications(remote_replication_id)
+        if err:
+            raise Exception('Could not fetch replication details: %s' % err)
+
+        replication = rr[0]
+        rsync_entries = replication['rsync'][0]
+        mode = replication['mode']
+        if mode != 'rsync':
+            raise Exception('Invalid replication mode')
+
+        source_path = rsync_entries['source_path']
+        target_path = rsync_entries['target_path']
+
+        source_dirs = [d for d in source_path[1:].split('/')]
+        if source_dirs[0] and source_dirs[1]:
+            source_fs = '%s/%s' % (source_dirs[0], source_dirs[1])
+        elif source_dirs[0]:
+            source_fs = '%s' % (source_dirs[0])
+        target_dirs = [d for d in target_path[1:].split('/')]
+        if target_dirs[0] and target_dirs[1]:
+            target_fs = '%s/%s' % (target_dirs[0], target_dirs[1])
+        elif target_dirs[0]:
+            target_fs = '%s' % (target_dirs[0])
+
+    except Exception, e:
+        return None, str(e)
+    else:
+        return {'source_fs': source_fs, 'target_fs': target_fs}, None
 
 
 def add_remote_replication(mode, entries):
@@ -136,11 +352,11 @@ def _add_rsync_remote_replication(remote_replication_id, entries):
         if err:
             raise Exception(err)
 
-        if ('rsync_type' and 'short_switches' and 'long_switches' and 'source_path' and 'target_path' and 'target_ip' and 'target_user_name') not in entries:
+        if ('rsync_type' and 'short_switches' and 'long_switches' and 'source_path' and 'target_path' and 'target_ip' and 'is_between_integralstor' and 'target_user_name' and 'description' and 'schedule') not in entries:
             raise Exception('Invalid parameters')
 
-        rsync_repl_cmd = "insert into rsync_replications (remote_replication_id,rsync_type,short_switches,long_switches,source_path,target_path,target_ip,target_user_name) values ('%d','%s','%s','%s','%s','%s','%s','%s')" % (
-            remote_replication_id, entries['rsync_type'], entries['short_switches'], entries['long_switches'], entries['source_path'], entries['target_path'], entries['target_ip'], entries['target_user_name'])
+        rsync_repl_cmd = "insert into rsync_replications (remote_replication_id,rsync_type,short_switches,long_switches,source_path,target_path,target_ip,is_between_integralstor,target_user_name) values ('%d','%s','%s','%s','%s','%s','%s','%s','%s')" % (
+            remote_replication_id, entries['rsync_type'], entries['short_switches'], entries['long_switches'], entries['source_path'], entries['target_path'], entries['target_ip'], entries['is_between_integralstor'], entries['target_user_name'])
 
         rsync_remote_replication_id, err = db.execute_iud(
             db_path, [[rsync_repl_cmd], ], get_rowid=True)
@@ -309,35 +525,6 @@ def delete_remote_replication(remote_replication_id):
         if err:
             raise Exception(err)
 
-        # Uncomment the following block if 'ON DELETE CASCADE' switch
-        # is removed from the replication related tables in the DB
-        """
-        # Reverting a delete is not possible. If this fails, we will
-        # end up with dangling entries. Better to remove from
-        # remote_replications table first because they used for display
-        # in views. A dangling entry in remote_replications table is
-        # very misleading, but one in mode specific tables is not so
-        # problematic since they aren't used for listing in
-        # IntegralView directly.
-        rr_cmd = "delete from remote_replications where remote_replication_id='%s'" % remote_replication_id
-        rowid, err = db.execute_iud(db_path, [[rr_cmd], ], get_rowid=False)
-        if err:
-            raise Exception(err)
-
-        if replications[0]['mode'] == 'zfs':
-            zfs_cmd = "delete from zfs_replications where remote_replication_id='%s'" % remote_replication_id
-            rowid, err = db.execute_iud(
-                db_path, [[zfs_cmd], ], get_rowid=False)
-            if err:
-                raise Exception(err)
-        elif replications[0]['mode'] == 'rsync':
-            rsync_cmd = "delete from rsync_replications where remote_replication_id='%s'" % remote_replication_id
-            rowid, err = db.execute_iud(
-                db_path, [[rsync_cmd], ], get_rowid=False)
-            if err:
-                raise Exception(err)
-        """
-
     except Exception, e:
         return False, 'Error deleting remote replication task: %s' % e
     else:
@@ -480,9 +667,9 @@ def run_rsync_remote_replication(remote_replication_id):
 
         description = replication['description']
         rsync_entries = replication['rsync'][0]
-
         rsync_type = rsync_entries['rsync_type']
-        source_path = rsync_entries['source_path']
+        source_path = None
+        source_path_live = rsync_entries['source_path']
         target_path = rsync_entries['target_path']
         short_switches = rsync_entries['short_switches']
         long_switches = rsync_entries['long_switches']
@@ -491,13 +678,12 @@ def run_rsync_remote_replication(remote_replication_id):
         run_as_user_name = 'replicator'
 
         rr, err = get_remote_replications_with('rsync',
-                                               {'source_path': source_path, 'target_ip': remote_ip, 'target_path': target_path})
+                                               {'source_path': source_path_live, 'target_ip': remote_ip, 'target_path': target_path})
         if err:
             raise Exception(err)
         if not rr:
             raise Exception(
                 'Could not locate the specified remote replication task')
-
         # Check for active replication tasks
         is_running, err = scheduler_utils.is_task_running(
             rr[0][0]['cron_task_id'], 4, True)
@@ -508,32 +694,54 @@ def run_rsync_remote_replication(remote_replication_id):
             audit.audit("task_fail", audit_str, None, system_initiated=True)
             raise Exception(audit_str)
 
-        cmd_arg = ''
-        source = ''
-        target = ''
-        if rsync_type == 'pull':
-            source = '%s@%s:%s' % (
-                remote_user_name, remote_ip, source_path)
-            target = target_path
-        elif rsync_type == 'push':
-            target = '%s@%s:%s' % (
-                remote_user_name, remote_ip, target_path)
-            source = source_path
-        elif rsync_type == 'local':
-            target = target_path
-            source = source_path
-            # since rsync type 'local' is with in the machine
-            run_as_user_name = 'integralstor'
+        zfs_source_snap = None
+        rename_snap_cmd = ''
+        create_snap_cmd = ''
+        if rsync_entries['is_between_integralstor'] == 'True':
+            zfs_source_snap, err = sync_snapshot_prior_rsync(
+                remote_replication_id)
+            if err:
+                raise Exception(err)
+            post_run_cmds, err = get_snapshot_sync_cmd_post_rsync(
+                remote_replication_id, zfs_source_snap)
+            if err:
+                raise Exception(err)
+            rename_snap_cmd = post_run_cmds['rename_snap_cmd']
+            create_snap_cmd = post_run_cmds['create_snap_cmd']
+        if rsync_entries['is_between_integralstor'] is 'True' and zfs_source_snap is None:
+            raise Exception('Snapshot name is required')
 
+        # if snapshot name is provided, include its path
+        if zfs_source_snap is not None:
+            snap_path = '.zfs/snapshot/%s' % zfs_source_snap
+            # split by '/' to get all directory names in the path
+            dirs = [i for i in source_path_live.split('/')]
+            # dirs[0] will be an empty string, keep it.
+            # dirs[1] will be pool name
+            # dirs[2] will be filesystem name
+            dirs.insert(3, snap_path)
+            source_path = '/'.join(dirs)
+        else:
+            source_path = source_path_live
+
+        paths, err = rsync.form_rsync_paths_command(
+            rsync_type, source_path, target_path, remote_ip, remote_user_name)
+        if err:
+            raise Exception(err)
+        source = paths['source_path']
+        target = paths['target_path']
+
+        cmd_arg = ''
         if rsync_type in ['push', 'pull']:
-            cmd_arg = 'sudo rsync -hivOP %s %s --stats --exclude=urbackup_tmp_files -e \\"ssh -l replicator -i /home/replicator/.ssh/id_rsa -o ServerAliveInterval=300 -o ServerAliveCountMax=3\\" %s %s' % (
+            cmd_arg = 'sudo rsync -hiOP %s %s --stats -e \\"ssh -l replicator -i /home/replicator/.ssh/id_rsa -o ServerAliveInterval=300 -o ServerAliveCountMax=3\\" %s %s' % (
                 short_switches, long_switches, source, target)
         elif rsync_type in ['local']:
-            cmd_arg = 'rsync -hivOP %s %s --stats --exclude=urbackup_tmp_files %s %s' % (
+            cmd_arg = 'rsync -hiOP %s %s --stats %s %s' % (
                 short_switches, long_switches, source, target)
 
         path = '%s/rsync_replicator.sh' % scripts_path
-        cmd = '/bin/bash %s "%s"' % (path, cmd_arg)
+        cmd = '/bin/bash %s "%s" "%s" "%s"' % (path,
+                                               cmd_arg, rename_snap_cmd, create_snap_cmd)
 
         # Retry upto 3 times(default) with a retry interval of 1 hour
         ret, err = scheduler_utils.create_task(description, [
@@ -631,7 +839,11 @@ if __name__ == "__main__":
     # on machine 12.12.12.12", 'zfs', {'source_dataset':'try-try/ds',
     # 'target_ip':'12.12.12.12', 'target_user_name':'replicator',
     # 'target_pool':'dd'})
-    print get_remote_replications(29)
+    # print get_remote_replications(1)
+    # print sync_snapshot_prior_rsync(6)
+    # print get_snapshot_sync_cmd_post_rsync(5, "rrr_tmp")
+    print get_source_target_fs_names(8)
+    print run_rsync_remote_replication(8)
     pass
 
 # vim: tabstop=8 softtabstop=0 expandtab ai shiftwidth=4 smarttab

--- a/site-packages/integralstor/rsync.py
+++ b/site-packages/integralstor/rsync.py
@@ -171,6 +171,38 @@ def form_switches_command(switches):
         return switches_formed, None
 
 
+def form_rsync_paths_command(rsync_type, source, target, remote_ip, remote_user_name):
+    """Form 'source_path' and 'target_path' in a format that is rsync command ready
+
+    Returns:    (dict, None) or (None, str)
+                - A dictionary with 'source_path' & 'target_path' if successful, else,
+                  (none, "Error string")
+    """
+    source_path = ''
+    target_path = ''
+    try:
+        if (not (rsync_type and source and target and remote_ip and remote_user_name)):
+            raise Exception('Invalid parameters')
+        if rsync_type not in ['pull','push','local']:
+            raise Exception('Invalid parameters')
+        if rsync_type == 'pull':
+            source_path = '%s@%s:%s' % (
+                remote_user_name, remote_ip, source)
+            target_path = target
+        elif rsync_type == 'push':
+            target_path = '%s@%s:%s' % (
+                remote_user_name, remote_ip, target)
+            source_path = source
+        elif rsync_type == 'local':
+            target_path = target
+            source_path = source
+
+    except Exception, e:
+        return None, 'Could not form paths: %s' % str(e)
+    else:
+        return {'source_path': source_path, 'target_path': target_path}, None
+
+
 def _generate_rsync_config():
     """
     This generates the rsync config.
@@ -326,11 +358,16 @@ def main():
     # print load_shares_list()
     # print delete_rsync_share("test")
     # print _generate_rsync_config()
+    print form_rsync_paths_command('pull','/tank/ds1','/tar-tank/ds1','2.2.2.2','replicator')
+    print form_rsync_paths_command('push','/tank/ds1','/tar-tank/ds1','2.2.2.2','replicator')
+    print form_rsync_paths_command('local','/tank/ds1','/tar-tank/ds1','2.2.2.2','replicator')
+    """
     sw, err = get_available_switches()
     print sw
     print '-' * 10
     for s in sw:
         print sw[s]
+    """
     pass
 
 


### PR DESCRIPTION
Syncs ZFS snapshot between the hosts involved in the rsync
replication

Every rsync replication moves data from a snapshot, not the live
filesystem. Create a temporary snapshot specific to the replication id
on the source. If a temporary snapshot already exists, no new snapshot
is created.

The rsync shell script which runs the actual replication does the
snapshot sync post replication run. On a successful run, the
temporary snapshot is renamed on the source side. So, if there's a
temporary snapshot present, it's safe to assume that the previous
run for that replication id did not complete successfully.

Signed-off-by: six-k <ramsri.hp@gmail.com>