### PR TITLE
Cleanup of the manifest and status generation for integralstor

### DIFF
--- a/integral_view/templates/update_manifest.html
+++ b/integral_view/templates/update_manifest.html
@@ -72,6 +72,6 @@
 
 {% block tab_active %}
   <script>
-    make_tab_active("node_info_tab")
+    make_tab_active("system_info_tab")
   </script>
 {% endblock %}

--- a/integral_view/templates/view_system_info.html
+++ b/integral_view/templates/view_system_info.html
@@ -42,10 +42,44 @@
 </script>
 
   <table class="table table-bordered table-striped table-hover" style="width:60%">
+    {%if node.hardware_specific_info %}
+      {%if node.hardware_specific_info.system_manufacturer%}
+        <tr>
+          <th> Hardware manufacturer </th>
+          <td>
+            {{node.hardware_specific_info.system_manufacturer}} 
+          </td>
+        </tr>
+      {%endif%}
+      {%if node.hardware_specific_info.product_name%}
+        <tr>
+          <th> Hardware product name </th>
+          <td>
+            {{node.hardware_specific_info.product_name}} 
+          </td>
+        </tr>
+      {%endif%}
+      {%if node.hardware_specific_info.system_version%}
+        <tr>
+          <th> Hardware system version</th>
+          <td>
+            {{node.hardware_specific_info.system_version}} 
+          </td>
+        </tr>
+      {%endif%}
+      {%if node.hardware_specific_info.system_serial_number%}
+        <tr>
+          <th> Hardware system serial number</th>
+          <td>
+            {{node.hardware_specific_info.system_serial_number}} 
+          </td>
+        </tr>
+      {%endif%}
+    {%endif%}
     <tr>
       <th> CPU </th>
       <td>
-        {{node.cpu_model}}
+        {{node.cpu_model}} {%if node.cpu_cores%} ({{node.cpu_cores}} core(s)){%endif%}
       </td>
     </tr>
     <tr>

--- a/scripts/python/generate_manifest.py
+++ b/scripts/python/generate_manifest.py
@@ -17,7 +17,7 @@ def gen_manifest(path):
             raise Exception(err)
         if not lck:
             raise Exception('Could not acquire lock.')
-        ret, err = manifest_status.generate_manifest_info()
+        ret, err = manifest_status.generate_manifest_info(rescan_for_disks = True)
         if not ret:
             if err:
                 raise Exception(err)

--- a/scripts/python/generate_status.py
+++ b/scripts/python/generate_status.py
@@ -26,8 +26,8 @@ def gen_status(path, lg=None):
                 raise Exception(err)
             else:
                 raise Exception('No status info obtained')
-        if ret and ('errors' in ret[ret.keys()[0]]) and ret[ret.keys()[0]]['errors']:
-            retval, err = alerts.record_alerts(ret[ret.keys()[0]]['errors'])
+        if ret and ('errors' in ret) and ret['errors']:
+            retval, err = alerts.record_alerts(ret['errors'])
             #print retval, err
         fullpath = os.path.normpath("%s/master.status" % path)
         fulltmppath = "/tmp/master.status.tmp"

--- a/scripts/python/generate_system_status_report.py
+++ b/scripts/python/generate_system_status_report.py
@@ -48,11 +48,12 @@ def main():
             f.write('\n\n')
             ret, err = generate_memory_section(f)
             f.write('\n\n')
+            ret, err = generate_dmidecode_section(f)
+            print ret, err
+            f.write('\n\n')
             hw_platform, err = config.get_hardware_platform()
             if hw_platform:
                 if hw_platform == 'dell':
-                    ret, err = generate_command_based_section(f, 'dmidecode -s system-serial-number', 'Dell service tag')
-                    f.write('\n\n')
                     ret, err = generate_dell_hw_status(f)
                     f.write('\n\n')
             ret, err = generate_alerts_section(f, start_time)
@@ -288,6 +289,24 @@ def generate_command_based_section(f, cmd, section_name):
         f.write( '--------------------- %s END ------------------------\n\n'%section_name)
     except Exception, e:
         return False, 'Error generating %s section: %s'%(section_name, str(e))
+    else:
+        return True, None
+
+def generate_dmidecode_section(f):
+    try:
+        f.write( '--------------------- Hardware information BEGIN------------------------\n\n')
+        lines, err = command.get_command_output('dmidecode -s system-manufacturer')
+        f.write( 'System manufacturer : %s\n'%lines[0])
+        lines, err = command.get_command_output('dmidecode -s system-product-name')
+        f.write( 'System product name : %s\n'%lines[0])
+        lines, err = command.get_command_output('dmidecode -s system-version')
+        f.write( 'System version : %s\n'%lines[0])
+        lines, err = command.get_command_output('dmidecode -s system-serial-number')
+        f.write( 'System serial number (service tag) : %s\n'%lines[0])
+        f.write( '\n')
+        f.write( '--------------------- Hardware information END ------------------------\n\n')
+    except Exception, e:
+        return False, 'Error generating hardware information section: %s'%(str(e))
     else:
         return True, None
 

--- a/site-packages/integralstor/manifest_status.py
+++ b/site-packages/integralstor/manifest_status.py
@@ -40,6 +40,53 @@ def get_zfs_version():
         return zfs_ver, None
 
 
+def get_disk_info(rescan=False):
+    return_dict = None
+    try:
+        return_dict, err = disks.get_disk_info_status_all(
+            rescan=rescan, type='info')
+        if err:
+            raise Exception(err)
+    except Exception, e:
+        return None, 'Error retrieving disk information : %s' % str(e)
+    else:
+        return return_dict, None
+
+
+def get_disk_status():
+    return_dict = None
+    try:
+        return_dict, err = disks.get_disk_info_status_all(
+            rescan=False, type='status')
+        if err:
+            raise Exception(err)
+        if return_dict:
+            pool_list, err = zfs.get_pools()
+            if pool_list:
+                for sn, disk in return_dict.items():
+                    # print disk['name']
+                    id, err = disks.get_disk_id(disk['name'])
+                    if err:
+                        raise Exception(err)
+                    # print id
+                    #id = disk['id']
+                    found = False
+                    for pool in pool_list:
+                        devices_list, err = zfs.get_disks_in_component(
+                            pool['config']['pool']['root'])
+                        if err:
+                            raise Exception(err)
+                        # print 'devices list is ', devices_list
+                        # print 'id is', id
+                        if devices_list and id in devices_list:
+                            # print 'in devices list'
+                            disk['pool'] = pool['pool_name']
+    except Exception, e:
+        return None, 'Error retrieving disk status : %s' % str(e)
+    else:
+        return return_dict, None
+
+
 def get_disk_info_and_status():
 
     all_disks = None
@@ -80,6 +127,25 @@ def get_pool_status():
         return pl, None
 
 
+def get_interface_info():
+    """Gets a more concise version of the interface info than networking provides."""
+    d = {}
+    try:
+        ifaces, err = networking.get_interfaces()
+        if err:
+            raise Exception(err)
+        # print ifaces
+        if ifaces:
+            for iface_name, iface in ifaces.items():
+                td = {}
+                td['hwaddr'] = iface['addresses']['AF_LINK'][0]['addr']
+                d[iface_name] = td
+    except Exception, e:
+        return None, 'Error retrieving interface info : %s' % str(e)
+    else:
+        return d, None
+
+
 def get_interface_status():
     """Gets a more concise version of the interface info and status than networking provides."""
     d = {}
@@ -91,7 +157,6 @@ def get_interface_status():
         if ifaces:
             for iface_name, iface in ifaces.items():
                 td = {}
-                td['hwaddr'] = iface['addresses']['AF_LINK'][0]['addr']
                 td['up'] = iface['up_status']
                 if 'AF_INET' in iface['addresses'] and iface['addresses']['AF_INET'] and iface['addresses']['AF_INET'][0]:
                     inet_list = []
@@ -129,9 +194,9 @@ def get_load_avg():
             line = f.readline()
             parts = line.split()
             if parts:
-                d['1-min'] = float(parts[0])
-                d['5-min'] = float(parts[1])
-                d['15-min'] = float(parts[2])
+                d['1_min'] = float(parts[0])
+                d['5_min'] = float(parts[1])
+                d['15_min'] = float(parts[2])
         cores, err = get_cpu_cores()
         if err:
             raise Exception(err)
@@ -160,53 +225,61 @@ def get_cpu_cores():
         return cores, None
 
 
-def get_mem_info():
+def get_mem_info_status(type='all'):
     """The total and the used memory information."""
     ret = {}
     try:
+        if type not in ['info', 'status', 'all']:
+            raise Exception('Invalid type passed.')
         mem_total = None
         mem_free = None
         with open('/proc/meminfo', 'r') as f:
             lines = f.readlines()
+            mem_total = {}
+            mem_free = {}
             for line in lines:
-                match = re.match(
-                    'MemTotal\s*:\s+([\S]+)\s+(\S+)$', line.strip())
-                if match:
-                    grps = match.groups()
-                    if grps:
-                        mem_total = {}
-                        mem_total['unit'] = grps[1]
-                        mem_total['value'] = int(grps[0])
-                        if mem_total['unit'] == 'kB':
-                            mem_total['unit'] = 'GB'
-                            mem_total['value'] = float(
-                                mem_total['value']) / 1024 / 1024
-                        elif mem_total['unit'] == 'mB':
-                            mem_total['unit'] = 'GB'
-                            mem_total['value'] = float(
-                                mem_total['value']) / 1024
-                match = re.match(
-                    'MemFree\s*:\s+([\S]+)\s+(\S+)$', line.strip())
-                if match:
-                    grps = match.groups()
-                    if grps:
-                        mem_free = {}
-                        mem_free['unit'] = grps[1]
-                        mem_free['value'] = int(grps[0])
-                        if mem_free['unit'] == 'kB':
-                            mem_free['unit'] = 'GB'
-                            mem_free['value'] = float(
-                                mem_free['value']) / 1024 / 1024
-                        elif mem_free['unit'] == 'mB':
-                            mem_free['unit'] = 'GB'
-                            mem_free['value'] = float(
-                                mem_total['value']) / 1024
-                if mem_total and mem_free:
-                    break
-        if not mem_total and not mem_free:
-            raise Exception('Error retrieving memory information')
-        ret['mem_total'] = mem_total
-        ret['mem_free'] = mem_free
+                if type in ['info', 'all']:
+                    match = re.match(
+                        'MemTotal\s*:\s+([\S]+)\s+(\S+)$', line.strip())
+                    if match:
+                        grps = match.groups()
+                        if grps:
+                            mem_total['unit'] = grps[1]
+                            mem_total['value'] = int(grps[0])
+                            if mem_total['unit'] == 'kB':
+                                mem_total['unit'] = 'GB'
+                                mem_total['value'] = int(float(
+                                    mem_total['value']) / 1024 / 1024)
+                            elif mem_total['unit'] == 'mB':
+                                mem_total['unit'] = 'GB'
+                                mem_total['value'] = int(float(
+                                    mem_total['value']) / 1024)
+                    if mem_total:
+                        ret['mem_total'] = mem_total
+                        break
+                if type in ['status', 'all']:
+                    match = re.match(
+                        'MemFree\s*:\s+([\S]+)\s+(\S+)$', line.strip())
+                    if match:
+                        grps = match.groups()
+                        if grps:
+                            mem_free['unit'] = grps[1]
+                            mem_free['value'] = int(grps[0])
+                            if mem_free['unit'] == 'kB':
+                                mem_free['unit'] = 'GB'
+                                mem_free['value'] = int(float(
+                                    mem_free['value']) / 1024 / 1024)
+                            elif mem_free['unit'] == 'mB':
+                                mem_free['unit'] = 'GB'
+                                mem_free['value'] = int(float(
+                                    mem_total['value']) / 1024)
+                    if mem_free:
+                        ret['mem_free'] = mem_free
+                        break
+            if (type in ['info', 'all'] and not mem_total):
+                raise Exception('Error retrieving memory information')
+            if (type in ['status', 'all'] and not mem_free):
+                raise Exception('Error retrieving memory information')
     except Exception, e:
         return None, 'Error retrieving memory information: %s' % str(e)
     else:
@@ -319,6 +392,30 @@ def get_ipmi_status():
 def get_hardware_specific_info():
     return_dict = {}
     try:
+        lines, err = command.get_command_output(
+            'dmidecode -s system-manufacturer')
+        if not err and lines and lines[0].lower() != 'none':
+            return_dict['system_manufacturer'] = lines[0]
+        lines, err = command.get_command_output(
+            'dmidecode -s system-product-name')
+        if not err and lines and lines[0].lower() != 'none':
+            return_dict['system_product_name'] = lines[0]
+        lines, err = command.get_command_output('dmidecode -s system-version')
+        if not err and lines and lines[0].lower() != 'none':
+            return_dict['system_version'] = lines[0]
+        lines, err = command.get_command_output(
+            'dmidecode -s system-serial-number')
+        if not err and lines and lines[0].lower() != 'none':
+            return_dict['system_serial_number'] = lines[0]
+    except Exception, e:
+        return None, 'Error retrieving hardware specific info: %s' % str(e)
+    else:
+        return return_dict, None
+
+
+def get_hardware_specific_status():
+    return_dict = {}
+    try:
         hw_platform, err = config.get_hardware_platform()
         if hw_platform:
             return_dict['hw_platform'] = hw_platform
@@ -329,159 +426,46 @@ def get_hardware_specific_info():
                 if idrac_url:
                     return_dict['idrac_url'] = idrac_url
     except Exception, e:
-        return None, 'Error retrieving hardware specific information: %s' % str(e)
+        return None, 'Error retrieving hardware specific status: %s' % str(e)
     else:
         return return_dict, None
 
 
-
-def get_status():
-    """Overall status info about the system combining all of the above into one big dict."""
-    d = {}
-    try:
-        zfs_ver, err = get_zfs_version()
-        if err:
-            raise Exception(err)
-        d["zfs_version"] = zfs_ver
-
-        os_ver = '%s %s' % (platform.system(), platform.release())
-        d["os_version"] = os_ver
-
-        dis, err = get_disk_info_and_status()
-        if err:
-            raise Exception(err)
-        d["disks"] = dis
-
-        services_stat, err = get_services_status()
-        if err:
-            raise Exception(err)
-        d["services"] = services_stat
-
-        iface_status, err = get_interface_status()
-        if err:
-            raise Exception(err)
-        d["interfaces"] = iface_status
-
-        pl, err = zfs.get_pools()
-        if err:
-            raise Exception(err)
-        d["pools"] = pl
-
-        lavg, err = get_load_avg()
-        if err:
-            raise Exception(err)
-        d["load_avg"] = lavg
-
-        meminfo, err = get_mem_info()
-        if err:
-            raise Exception(err)
-        d["memory"] = meminfo
-
-        ipmi, err = get_ipmi_status()
-        if ipmi:
-            d["ipmi_status"] = ipmi
-
-        cm, err = get_cpu_model()
-        if err:
-            raise Exception(err)
-        d["cpu_model"] = cm
-
-        fqdn = socket.getfqdn()
-        d["fqdn"] = fqdn
-
-        hardware_dict, err = get_hardware_specific_info()
-        if err:
-            raise Exception(err)
-        d["hardware_specific_dict"] = hardware_dict
-
-    except Exception, e:
-        return None, 'Error retrieving system status: %s' % str(e)
-    else:
-        return d, None
-
-
-def generate_manifest_info():
+def generate_manifest_info(rescan_for_disks=False):
     """Generate a dictionary containing all manifest information. Will be dumped into the master.manifest file in a json format."""
     manifest_dict = {}
     try:
-        #pp = pprint.PrettyPrinter(indent=4)
-
-        use_salt, err = config.use_salt()
+        cpu_model, err = get_cpu_model()
         if err:
             raise Exception(err)
-        fqdn = socket.getfqdn()
-        if use_salt:
-            import salt.modules.network
-            import salt.modules.ps
-            import salt.modules.status
-            import salt.client
-            import salt.wheel
-            import salt.config
-            local = salt.client.LocalClient()
+        manifest_dict['cpu_model'] = cpu_model
 
-            cfg, err = config.get_salt_master_config()
-            if err:
-                raise Exception(err)
-            opts = salt.config.master_config(cfg)
-            wheel = salt.wheel.Wheel(opts)
-            keys = wheel.call_func('key.list_all')
-            if not keys:
-                raise Exception('No GRIDCells found!')
-            nodes = keys['minions']
-            # print nodes
-            for node in nodes:
-                manifest_dict[node] = {}
+        cpu_cores, err = get_cpu_cores()
+        if err:
+            raise Exception(err)
+        manifest_dict['cpu_cores'] = cpu_cores
 
-            roles = local.cmd('*', 'grains.item', ['roles'])
-            for node, info in roles.items():
-                if node not in manifest_dict:
-                    manifest_dict[node] = {}
-                manifest_dict[node]['roles'] = info['roles']
-            ret = local.cmd('*', 'integralstor.status')
-            for node, info in ret.items():
-                if node not in manifest_dict:
-                    manifest_dict[node] = {}
-                manifest_dict[node]['cpu_model'] = info['cpu_model']
-                manifest_dict[node]['disks'] = info['disks']
-                for dn, dv in manifest_dict[node]['disks'].items():
-                    if 'pool' in dv:
-                        dv.pop('pool')
-                manifest_dict[node]['interfaces'] = info['interfaces']
-                manifest_dict[node]['memory'] = info['memory']
-                manifest_dict[node]['fqdn'] = info['fqdn']
-                if 'hardware_specific_dict' in info:
-                    manifest_dict[node]['hardware_specific_dict'] = info['hardware_specific_dict']
-        else:
-            # Single node so get the info using a direct call and just bung it
-            # into the fqdn key!
-            manifest_dict[fqdn] = {}
-            status_dict, err = get_status()
-            if err:
-                raise Exception(err)
-            manifest_dict[fqdn]['cpu_model'] = status_dict['cpu_model']
-            manifest_dict[fqdn]['disks'] = status_dict['disks']
-            for dn, dv in manifest_dict[fqdn]['disks'].items():
-                if 'pool' in dv:
-                    dv.pop('pool')
-            manifest_dict[fqdn]['interfaces'] = status_dict['interfaces']
-            manifest_dict[fqdn]['memory'] = status_dict['memory']
-            manifest_dict[fqdn]['fqdn'] = fqdn
+        disk_info, err = disks.get_disk_info_status_all(
+            rescan=rescan_for_disks, type='info')
+        if err:
+            raise Exception(err)
+        manifest_dict['disks'] = disk_info
 
-        # Remove transitory info and only keep the actual hardware info
-        for node in manifest_dict.keys():
-            if 'interfaces' in manifest_dict[node]:
-                for int_name, interface in manifest_dict[node]['interfaces'].items():
-                    if 'up' in interface:
-                        interface.pop('up')
-                    if 'inet' in interface:
-                        interface.pop('inet')
-            if 'disks' in manifest_dict[node]:
-                for disk_name, diskinfo in manifest_dict[node]['disks'].items():
-                    if 'status' in diskinfo:
-                        diskinfo.pop('status')
-            if 'memory' in manifest_dict[node]:
-                if 'mem_free' in manifest_dict[node]['memory']:
-                    manifest_dict[node]['memory'].pop('mem_free')
+        meminfo, err = get_mem_info_status(type='info')
+        if err:
+            raise Exception(err)
+        manifest_dict['memory'] = meminfo
+
+        iface_info, err = get_interface_info()
+        if err:
+            raise Exception(err)
+        manifest_dict['interfaces'] = iface_info
+
+        hardware_info_dict, err = get_hardware_specific_info()
+        if err:
+            raise Exception(err)
+        if hardware_info_dict:
+            manifest_dict['hardware_specific_info'] = hardware_info_dict
 
         if not manifest_dict:
             raise Exception('Error getting manifest information')
@@ -519,239 +503,231 @@ Generate a dictionary containing all status information. Will be dumped into the
 
 
 def generate_status_info(path):
-    status_dict = None
+    status_dict = {}
     try:
         pp = pprint.PrettyPrinter(indent=4)
 
         # First load the status
         fqdn = socket.getfqdn()
-        use_salt, err = config.use_salt()
-        if err:
-            raise Exception(err)
-        if use_salt:
-            import salt.client
-            local = salt.client.LocalClient()
-            sd = local.cmd('*', 'integralstor.status')
-        else:
-            tmpsd, err = get_status()
-            if err:
-                raise Exception(err)
-            sd = {}
-            sd[fqdn] = tmpsd
-
-        # pp.pprint(sd)
-        if not sd:
-            raise Exception('Did not get a response from salt')
-        # pp.pprint(sd[fqdn]['interfaces'])
-
         # Load the manifest to check for discrepencies
         try:
             with open(path, 'r') as f:
-                md = json.load(f)
+                manifest_dict = json.load(f)
         except Exception, e:
             raise Exception('Error reading the manifest file : %s' % str(e))
         # pp.pprint(md)
 
-        status_dict = {}
-
         # Match the status against the manifest entries for discrepencies
-        for hostname, manifest in md.items():
-            # print hostname, len(hostname)
-            temp_d = {}
-            temp_d["errors"] = []
-            node_status = 0
-            # print sd.keys()
+        status_dict["errors"] = []
+        hardware_dict, err = get_hardware_specific_status()
+        if err:
+            raise Exception(err)
+        if hardware_dict:
+            status_dict['hardware_specific_status'] = hardware_dict
+        node_status = 0
 
-            if hostname not in sd.keys():
-                node_status = -1
-                # print "Not found in sd"
-            else:
-                if sd[hostname] and 'hardware_specific_dict' in sd[hostname]:
-                    temp_d['hardware_specific_dict'] = sd[hostname]['hardware_specific_dict']
-
-                # Process disk information
-                disks = {}
-                for disk_sn, disk in manifest["disks"].items():
-                    # print disk_sn
-                    # print sd[hostname]['disks'].keys()
-                    dd = {}
-                    if disk_sn in sd[hostname]["disks"]:
-                        dd["status"] = sd[hostname]["disks"][disk_sn]["status"]
-                        if dd['status']:
-                            if 'hw_raid' in disk and (not disk['hw_raid']):
-                                if (dd["status"].lowed() not in ['ok', 'passed']):
-                                    node_status = 1
-                                    temp_d["errors"].append(
-                                        { 'subsystem_type_id': 1, 'severity_type_id': 2, 'component' : disk_sn, 'alert_str' : "Disk with serial number %s is reporting SMART errors." % disk_sn})
-                        dd["name"] = sd[hostname]["disks"][disk_sn]["name"]
-                    else:
-                        sd[hostname]['disks'][disk_sn] = disk
-                        sd[hostname]['disks'][disk_sn]['status'] = 'Disk missing'
-                        dd["status"] = "Disk Missing"
-                        node_status = 1
-                        temp_d["errors"].append(
-                                        { 'subsystem_type_id': 1, 'severity_type_id': 3, 'component' :  disk_sn, 'alert_str' : 
-                            "Disk with serial number %s seems to be missing." % disk_sn})
-                    disks[disk_sn] = dd
-                new_disk = False
-                for td in sd[hostname]["disks"].keys():
-                    if td not in manifest["disks"]:
-                        new_disk = True
-                        temp_d["errors"].append(
-                            { 'subsystem_type_id': 1, 'severity_type_id': 1, 'component' : disk_sn, 'alert_str' : 
-                            "New disk detected. Disk with serial number %s  seems to be new." % td})
-                        node_status = 2
-                #temp_d["disks"] = disks
-                temp_d["disks"] = sd[hostname]['disks']
-                # pp.pprint(temp_d['disks'])
-
-                if sd[hostname]['services']:
-                    for service_name, service_info in sd[hostname]['services'].items():
-                        if service_info[0] != 0:
-                            temp_d['errors'].append(
-                                { 'subsystem_type_id': 2, 'severity_type_id': 3, 'component' : service_name, 'alert_str' : 
-                                'Service %s seems to have failed.' % service_name})
+        # Process disk information
+        disks_dict = {}
+        disk_status_dict, err = disks.get_disk_info_status_all(
+            rescan=False, type='status')
+        if err:
+            raise Exception(err)
+        # print disk_status_dict.keys()
+        for disk_sn, disk_info_dict in manifest_dict["disks"].items():
+            # print disk_info_dict
+            # print disk_sn
+            dd = {}
+            if disk_sn in disk_status_dict.keys():
+                dd["name"] = disk_status_dict[disk_sn]["name"]
+                dd["status"] = disk_status_dict[disk_sn]["status"]
+                if dd['status']:
+                    if ('hw_raid' not in disk_info_dict) or (not disk_info_dict['hw_raid']):
+                        if (dd["status"].lowed() not in ['ok', 'passed']):
                             node_status = 1
-                    temp_d["services"] = sd[hostname]['services']
+                            status_dict["errors"].append(
+                                {'subsystem_type_id': 1, 'severity_type_id': 2, 'component': disk_sn, 'alert_str': "Disk with serial number %s is reporting SMART errors." % disk_sn})
+            else:
+                dd['status'] = 'Disk missing'
+                node_status = 1
+                status_dict["errors"].append(
+                    {'subsystem_type_id': 1, 'severity_type_id': 3, 'component':  disk_sn, 'alert_str':
+                     "Disk with serial number %s seems to be missing." % disk_sn})
+            disks_dict[disk_sn] = dd
+            '''
+            #Dont detect new disks here because it requires a costly disk rescan
+            new_disk = False
+            for td in sd[hostname]["disks"].keys():
+                if td not in manifest["disks"]:
+                    new_disk = True
+                    status_dict["errors"].append(
+                        { 'subsystem_type_id': 1, 'severity_type_id': 1, 'component' : disk_sn, 'alert_str' : 
+                        "New disk detected. Disk with serial number %s  seems to be new." % td})
+                    node_status = 2
+            #temp_d["disks"] = disks
+            temp_d["disks"] = sd[hostname]['disks']
+            # pp.pprint(temp_d['disks'])
+            '''
+        status_dict['disks'] = disks_dict
 
-                # Process interface information
-                interfaces = {}
-                for ifname, ifdict in manifest["interfaces"].items():
-                    # Check for all initially present interfaces
-                    id = {}
-                    if ifname in sd[hostname]["interfaces"]:
-                        id, err = _convert_to_status_interface_dict(
-                            sd[hostname]["interfaces"][ifname])
-                        if err:
-                            raise Exception(err)
-                    else:
-                        id["status"] = "Interface Missing"
-                        node_status = 1
-                        temp_d["errors"].append(
-                            { 'subsystem_type_id': 3, 'severity_type_id': 3, 'component' : ifname, 'alert_str' : 
-                            "Interface with name %s seems to be missing." % ifname})
-                    interfaces[ifname] = id
-                for ifname, ifinfo in sd[hostname]["interfaces"].items():
-                    # Check for all newly created interfaces - bonds, vlans, etc
-                    # print 'ifname is ', ifname
-                    if ifname not in manifest["interfaces"]:
-                        id, err = _convert_to_status_interface_dict(
-                            sd[hostname]["interfaces"][ifname])
-                        if err:
-                            raise Exception(err)
-                        interfaces[ifname] = id
-                temp_d["interfaces"] = interfaces
+        services_status_dict, err = get_services_status()
+        if err:
+            raise Exception(err)
+        status_dict["services"] = services_status_dict
+        if services_status_dict:
+            for service_name, service_info in services_status_dict.items():
+                if service_info[0] != 0:
+                    status_dict['errors'].append(
+                        {'subsystem_type_id': 2, 'severity_type_id': 3, 'component': service_name, 'alert_str':
+                         'Service %s seems to have failed.' % service_name})
+                    node_status = 1
 
-                for ifname, id in temp_d['interfaces'].items():
-                    if ('ip_configured' in id or 'slave_to' in id)and id["status"] != 'up':
-                        node_status = 1
-                        temp_d["errors"].append(
-                            { 'subsystem_type_id': 3, 'severity_type_id': 3, 'component' : ifname, 'alert_str' : 
-                            "Interface %s is not up." % ifname})
-
-                # print 'interfaces are ', temp_d['interfaces']
-
-                if "memory" in sd[hostname]:
-                    if sd[hostname]["memory"]["mem_total"]["unit"] == "kB":
-                        sd[hostname]["memory"]["mem_total"]["value"] = str(
-                            int(sd[hostname]["memory"]["mem_total"]["value"]) / 1024)
-                        sd[hostname]["memory"]["mem_total"]["unit"] = "MB"
-                    if sd[hostname]["memory"]["mem_free"]["unit"] == "kB":
-                        sd[hostname]["memory"]["mem_free"]["value"] = str(
-                            int(sd[hostname]["memory"]["mem_free"]["value"]) / 1024)
-                        sd[hostname]["memory"]["mem_free"]["unit"] = "MB"
-                    temp_d["memory"] = sd[hostname]["memory"]
-                if "disk_usage" in sd[hostname]:
-                    temp_d["disk_usage"] = sd[hostname]["disk_usage"]
-                if "pools" in sd[hostname]:
-                    temp_d["pools"] = sd[hostname]["pools"]
-                if "load_avg" in sd[hostname]:
-                    # To get around a django quirk of not recognising hyphens
-                    # in dicts
-                    sd[hostname]["load_avg"]["15_min"] = sd[hostname]["load_avg"]["15-min"]
-                    sd[hostname]["load_avg"]["5_min"] = sd[hostname]["load_avg"]["5-min"]
-                    sd[hostname]["load_avg"]["1_min"] = sd[hostname]["load_avg"]["1-min"]
-                    sd[hostname]["load_avg"].pop("15-min", None)
-                    sd[hostname]["load_avg"].pop("5-min", None)
-                    sd[hostname]["load_avg"].pop("1-min", None)
-                    temp_d["load_avg"] = sd[hostname]["load_avg"]
-
-                if "cpu_model" in manifest:
-                    temp_d["cpu_model"] = manifest["cpu_model"]
-
-                if "fqdn" in manifest:
-                    temp_d["fqdn"] = manifest["fqdn"]
-
-                if 'ipmi_status' in sd[hostname]:
-                    temp_d["ipmi_status"] = sd[hostname]["ipmi_status"]
-
-                if temp_d["load_avg"]['15_min'] >= temp_d["load_avg"]['cpu_cores']:
-                    temp_d["errors"].append(
-                        { 'subsystem_type_id': 4, 'severity_type_id': 2, 'component' : 'None', 'alert_str' : 
-                        "The 15-minute load average has been high." })
-                    node_status = "Degraded"
-                '''
-                        "The 15-minute load average (%.2f) has been high." % temp_d["load_avg"]['15_min']})
-                '''
-                if temp_d["load_avg"]['5_min'] >= temp_d["load_avg"]['cpu_cores']:
-                    temp_d["errors"].append(
-                        { 'subsystem_type_id': 4, 'severity_type_id': 2, 'component' : 'None', 'alert_str' : 
-                        "The 5-minute load average has been high."})
-                '''
-                        "The 5-minute load average (%.2f) has been high." % temp_d["load_avg"]['5_min']})
-                '''
-
-                if 'ipmi_status' in temp_d:
-                    for status_item in temp_d['ipmi_status']:
-                        if status_item["status"] not in ['ok', 'nr']:
-                            temp_d["errors"].append(
-                            { 'subsystem_type_id': 5, 'severity_type_id': 2, 'component' : parameter_name, 'alert_str' : 
-                            'The %s of the %s is reporting errors' % (
-                                status_item["parameter_name"], status_item["component_name"])})
-
-                pools = temp_d["pools"]
-                component_status_dict, err = zfs.get_all_components_status(
-                    pools)
+        # Process interface information
+        interfaces = {}
+        interface_status_dict, err = get_interface_status()
+        if err:
+            raise Exception(err)
+        # Check the status of existing interfaces
+        for ifname, ifdict in manifest_dict["interfaces"].items():
+            # Check for all initially present interfaces
+            id = {}
+            if ifname in interface_status_dict:
+                id, err = _convert_to_status_interface_dict(
+                    interface_status_dict[ifname])
                 if err:
                     raise Exception(err)
-                if component_status_dict:
-                    for pool_name, component_status_list in component_status_dict.items():
-                        msg = None
-                        severity_type_id = 1
-                        for component in component_status_list:
-                            if 'status' in component and 'state' in component['status'] and component['status']['state'] != 'ONLINE':
-                                if component['type'].lower() == 'pool':
-                                    if component['status']['state'] == 'DEGRADED':
-                                        severity_type_id = 2
-                                    else:
-                                        severity_type_id = 3
-                                if not msg:
-                                    msg = "The ZFS pool '%s' has the following issue(s) : " % pool_name
-                                msg += "The component %s of type '%s' has a state of '%s'. " % (
-                                    component['name'], component['type'], component['status']['state'])
-                        if msg:
-                            temp_d['errors'].append(
-                                { 'subsystem_type_id': 6, 'severity_type_id': severity_type_id, 'component' : pool_name, 'alert_str' : msg})
+            else:
+                id["status"] = "Interface Missing"
+                node_status = 1
+                status_dict["errors"].append(
+                    {'subsystem_type_id': 3, 'severity_type_id': 3, 'component': ifname, 'alert_str':
+                     "Interface with name %s seems to be missing." % ifname})
+            interfaces[ifname] = id
+        # Check to see if there are any new interfaces
+        for ifname, ifinfo in interface_status_dict.items():
+            # Check for all newly created interfaces - bonds, vlans, etc
+            # print 'ifname is ', ifname
+            if ifname not in manifest_dict["interfaces"]:
+                id, err = _convert_to_status_interface_dict(
+                    interface_status_dict[ifname])
+                if err:
+                    raise Exception(err)
+                interfaces[ifname] = id
+        status_dict["interfaces"] = interfaces
 
-                temp_d['zfs_version'] = sd[hostname]['zfs_version']
-                temp_d['os_version'] = sd[hostname]['os_version']
+        for ifname, id in status_dict['interfaces'].items():
+            if ('ip_configured' in id or 'slave_to' in id)and id["status"] != 'up':
+                node_status = 1
+                status_dict["errors"].append(
+                    {'subsystem_type_id': 3, 'severity_type_id': 3, 'component': ifname, 'alert_str':
+                     "Interface %s is not up." % ifname})
 
-            temp_d["node_status"] = node_status
-            if node_status == 0:
-                temp_d["node_status_str"] = "Healthy"
-            elif node_status == 1:
-                temp_d["node_status_str"] = "Degraded"
-            elif node_status == 2:
-                temp_d["node_status_str"] = "New on-node hardware detected"
-            elif node_status == -1:
-                temp_d["node_status_str"] = "No response. Down?"
-                temp_d['errors'].append(
-                        { 'subsystem_type_id': 99, 'severity_type_id': 3, 'component' : hostname, 'alert_str' : 
-                        'Node %s seems to be down' % hostname})
+        # print 'interfaces are ', status_dict['interfaces']
 
-            status_dict[hostname] = temp_d
-            # print status_dict[hostname]["errors"]
-        # pp.pprint(status_dict)
+        mem_status_dict, err = get_mem_info_status(type='status')
+        if err:
+            raise Exception(err)
+        status_dict['memory'] = mem_status_dict
+        '''
+                if sd[hostname]["memory"]["mem_total"]["unit"] == "kB":
+                    sd[hostname]["memory"]["mem_total"]["value"] = str(
+                        int(sd[hostname]["memory"]["mem_total"]["value"]) / 1024)
+                    sd[hostname]["memory"]["mem_total"]["unit"] = "MB"
+                if sd[hostname]["memory"]["mem_free"]["unit"] == "kB":
+                    sd[hostname]["memory"]["mem_free"]["value"] = str(
+                        int(sd[hostname]["memory"]["mem_free"]["value"]) / 1024)
+                    sd[hostname]["memory"]["mem_free"]["unit"] = "MB"
+                temp_d["memory"] = sd[hostname]["memory"]
+        '''
+
+        lavg, err = get_load_avg()
+        if err:
+            raise Exception(err)
+        if lavg:
+            status_dict['load_avg'] = lavg
+
+        if fqdn:
+            status_dict['fqdn'] = fqdn
+
+        ipmi, err = get_ipmi_status()
+        if err:
+            raise Exception(err)
+        if ipmi:
+            status_dict["ipmi_status"] = ipmi
+
+        if status_dict["load_avg"]['15_min'] >= status_dict["load_avg"]['cpu_cores']:
+            status_dict["errors"].append(
+                {'subsystem_type_id': 4, 'severity_type_id': 2, 'component': 'None', 'alert_str':
+                 "The 15-minute load average has been high."})
+            node_status = 1
+            '''
+                    "The 15-minute load average (%.2f) has been high." % temp_d["load_avg"]['15_min']})
+            '''
+        if status_dict["load_avg"]['5_min'] >= status_dict["load_avg"]['cpu_cores']:
+            status_dict["errors"].append(
+                {'subsystem_type_id': 4, 'severity_type_id': 2, 'component': 'None', 'alert_str':
+                 "The 5-minute load average has been high."})
+            '''
+                    "The 5-minute load average (%.2f) has been high." % temp_d["load_avg"]['5_min']})
+            '''
+
+        if 'ipmi_status' in status_dict:
+            for status_item in status_dict['ipmi_status']:
+                if status_item["status"] not in ['ok', 'nr']:
+                    status_dict["errors"].append(
+                        {'subsystem_type_id': 5, 'severity_type_id': 2, 'component': parameter_name, 'alert_str':
+                         'The %s of the %s is reporting errors' % (
+                             status_item["parameter_name"], status_item["component_name"])})
+
+        pools, err = zfs.get_pools()
+        if err:
+            raise Exception(err)
+        if pools:
+            status_dict['pools'] = pools
+
+        component_status_dict, err = zfs.get_all_components_status(
+            pools)
+        if err:
+            raise Exception(err)
+        if component_status_dict:
+            for pool_name, component_status_list in component_status_dict.items():
+                msg = None
+                severity_type_id = 1
+                for component in component_status_list:
+                    if 'status' in component and 'state' in component['status'] and component['status']['state'] != 'ONLINE':
+                        if component['type'].lower() == 'pool':
+                            if component['status']['state'] == 'DEGRADED':
+                                severity_type_id = 2
+                            else:
+                                severity_type_id = 3
+                        if not msg:
+                            msg = "The ZFS pool '%s' has the following issue(s) : " % pool_name
+                        msg += "The component %s of type '%s' has a state of '%s'. " % (
+                            component['name'], component['type'], component['status']['state'])
+                if msg:
+                    status_dict['errors'].append(
+                        {'subsystem_type_id': 6, 'severity_type_id': severity_type_id, 'component': pool_name, 'alert_str': msg})
+
+        zfs_ver, err = get_zfs_version()
+        if err:
+            raise Exception(err)
+        status_dict["zfs_version"] = zfs_ver
+
+        os_ver = '%s %s' % (platform.system(), platform.release())
+        status_dict["os_version"] = os_ver
+
+        status_dict["node_status"] = node_status
+        if node_status == 0:
+            status_dict["node_status_str"] = "Healthy"
+        elif node_status == 1:
+            status_dict["node_status_str"] = "Degraded"
+        elif node_status == 2:
+            status_dict["node_status_str"] = "New on-node hardware detected"
+        elif node_status == -1:
+            status_dict["node_status_str"] = "No response. Down?"
+            status_dict['errors'].append(
+                {'subsystem_type_id': 99, 'severity_type_id': 3, 'component': hostname, 'alert_str':
+                 'Node %s seems to be down' % hostname})
+
     except Exception, e:
         return None, 'Error generating status : %s' % str(e)
     else:
@@ -768,21 +744,23 @@ def main():
     # print get_ipmi_status()
     # print get_mem_info()
     # print get_interface_status()
-    #pp.pprint(get_status())
+    # pp.pprint(get_status())
     # pp.pprint(generate_manifest_info())
     # pp.pprint(get_interface_status())
     # pp.pprint(get_services_status())
-    #ret, err = generate_manifest_info()
+    # pp.pprint(generate_manifest_info())
     # print ret, err
     # print ret.keys()
     # pp.pprint(get_interface_status())
     # pp.pprint(get_disk_info_and_status())
     # print zfs_version()
     # generate_status_info('/opt/integralstor/integralstor/config/status/master.manifest')
+    # pp.pprint(get_disk_status())
+    # pp.pprint(generate_status_info(
+    #    '/opt/integralstor/integralstor/config/status/master.manifest'))
+    # pp.pprint(generate_status_info('/opt/integralstor/integralstor_gridcell/config/status/master.manifest'))
     pp.pprint(generate_status_info(
         '/opt/integralstor/integralstor/config/status/master.manifest'))
-    # pp.pprint(generate_status_info('/opt/integralstor/integralstor_gridcell/config/status/master.manifest'))
-    # generate_status_info('/opt/integralstor/integralstor_gridcell/config/status/master.manifest')
     #r, err = generate_status_info('/opt/integralstor/integralstor/config/status/master.manifest')
     # print r, err
     # if err:

--- a/site-packages/integralstor/manifest_status.py
+++ b/site-packages/integralstor/manifest_status.py
@@ -256,7 +256,6 @@ def get_mem_info_status(type='all'):
                                     mem_total['value']) / 1024)
                     if mem_total:
                         ret['mem_total'] = mem_total
-                        break
                 if type in ['status', 'all']:
                     match = re.match(
                         'MemFree\s*:\s+([\S]+)\s+(\S+)$', line.strip())
@@ -275,7 +274,6 @@ def get_mem_info_status(type='all'):
                                     mem_total['value']) / 1024)
                     if mem_free:
                         ret['mem_free'] = mem_free
-                        break
             if (type in ['info', 'all'] and not mem_total):
                 raise Exception('Error retrieving memory information')
             if (type in ['status', 'all'] and not mem_free):

--- a/site-packages/integralstor/system_info.py
+++ b/site-packages/integralstor/system_info.py
@@ -6,7 +6,7 @@ from integralstor_utils import config, zfs
 
 def load_system_config(first_time=False):
 
-    d = None
+    return_dict = {}
     try:
         if first_time:
             system_status_path, err = config.get_tmp_path()
@@ -22,58 +22,26 @@ def load_system_config(first_time=False):
 
         try:
             with open(msfn, "r") as f:
-                ms_nodes = json.load(f)
+                status_dict = json.load(f)
             with open(mmfn, "r") as f:
-                mm_nodes = json.load(f)
+                manifest_dict = json.load(f)
         except IOError:
-            raise Exception("file-not-found")
+            raise Exception('file-not-found')
 
-        d = {}
-        # First load it with the master node keys
-        for k in mm_nodes.keys():
-            d[k] = mm_nodes[k]
+        # First load the return dict with the manifest keys
+        return_dict = manifest_dict.copy()
 
-        for k in d.keys():
-            if k not in ms_nodes:
-                continue
-            status_node = ms_nodes[k]
-            for sk in status_node.keys():
-                if sk not in d[k]:
-                    d[k][sk] = status_node[sk]
-                elif sk == "disks":
-                    for disk in status_node["disks"].keys():
-                        if disk in d[k]["disks"]:
-                            d[k]["disks"][disk].update(
-                                status_node["disks"][disk])
-                    pool_list, err = zfs.get_pools()
-                    if pool_list:
-                        for sn, disk in d[k]['disks'].items():
-                            id = disk['id']
-                            found = False
-                            for pool in pool_list:
-                                devices_list, err = zfs.get_disks_in_component(
-                                    pool['config']['pool']['root'])
-                                if err:
-                                    raise Exception(err)
-                                if devices_list and id in devices_list:
-                                    disk['pool'] = pool['pool_name']
-                        '''
-            else:
-              d[k]["disks"][disk] = status_node["disks"][disk]
-            '''
-                elif sk == "interfaces":
-                    for interface in status_node["interfaces"].keys():
-                        if interface in d[k]["interfaces"]:
-                            d[k]["interfaces"][interface].update(
-                                status_node["interfaces"][interface])
-                        '''
-            else:
-              d[k]["interfaces"][interface] = status_node["interfaces"][interface]
-            '''
-                elif sk == "memory":
-                    for mem_key in status_node["memory"].keys():
-                        if mem_key not in d[k]["memory"]:
-                            d[k]["memory"][mem_key] = status_node["memory"][mem_key]
+        for k in return_dict.keys():
+            if k in status_dict.keys():
+                if k in ['disks', 'interfaces', 'memory']:
+                    for component in return_dict[k].keys():
+                        if component in status_dict[k].keys():
+                            for component_key in status_dict[k][component].keys():
+                                if component_key not in return_dict[k][component].keys():
+                                    return_dict[k][component][component_key] = status_dict[k][component][component_key]
+        for k in status_dict.keys():
+            if k not in return_dict.keys():
+                return_dict[k] = status_dict[k]
 
     except Exception, e:
         if str(e) is "file-not-found":
@@ -81,7 +49,7 @@ def load_system_config(first_time=False):
         else:
             return None, 'Error loading system configuration : %s' % str(e)
     else:
-        return d, None
+        return return_dict, None
 
 
 # vim: tabstop=8 softtabstop=0 expandtab ai shiftwidth=4 smarttab


### PR DESCRIPTION
A lot of the functions were getting both the static info and the dynamic status info. This has been separated out. The format of the manifest and status files has not been modified to remove the node name as the primary key of the dictionary as it is not needed for integralstor (at least until we have HA!). Also status generation will no longer alert about new disks - that will only be part of manifest generation and disk replacement as that is a time consuming process..

Have also added some dmidecode based hardware info to the manifest and updated the system info screen to show this.