### PR TITLE
Validate ZFS pool import

### DIFF
--- a/integral_view/forms/zfs_forms.py
+++ b/integral_view/forms/zfs_forms.py
@@ -141,7 +141,20 @@ class QuotaForm(forms.Form):
 
 
 class ImportPoolForm(forms.Form):
-    name = forms.CharField()
+    def __init__(self, *args, **kwargs):
+        pools = []
+        if kwargs and ('exported_pools' and 'destroyed_pools' in kwargs):
+            [pools.append(name) for name in kwargs.pop('exported_pools')]
+            [pools.append(name) for name in kwargs.pop('destroyed_pools')]
+
+        super(ImportPoolForm, self).__init__(*args, **kwargs)
+        ch = []
+        if pools:
+            for pool in pools:
+                tup = (str(pool), str(pool))
+                ch.append(tup)
+
+            self.fields['name'] = forms.ChoiceField(choices=ch, widget=forms.Select())
 
 
 class CreatePoolForm(forms.Form):

--- a/integral_view/templates/import_zfs_pool.html
+++ b/integral_view/templates/import_zfs_pool.html
@@ -9,18 +9,38 @@
   <form id="import_form" name="import_form" action="/import_zfs_pool/" method="POST">
     {%csrf_token%}
     <table class="table" style="width:800px">
-      <tr>
+    {% if form.name %}
+        <tr>
+        <h5> Available pools: </h5>
+        {% for choice in form.name.field.choices %}
+            <h5 style="padding-left: 8em;"> - {{choice.1}} </h5>
+        {% endfor %}
+        </tr>
+
+        <tr>
         <th> Pool name:</th>
         <td>
-          <input type="text"  name="name" class="form-control" id="id_name" placeholder="Enter the name of the pool" />
+          <select id = "id_name" name="name" class="form-control">
+            {% for choice in form.name.field.choices %}
+                    <option id="id_{{choice.1}}" value="{{choice.0}}">{{choice.1}}</option>
+            {%endfor%}
+          </select>
         </td>
         <td> {{ form.name.errors }} </td>
-      </tr>
-      </table>
+        <td>&nbsp;</td>
+        </tr>
+
+    {% else %}
+        <tr>
+        <h5 id="p-warning-text"> No pools to import! </h5>
+        </tr>
+    {% endif %}
+
+    </table>
 
     <div class="btn-group btn-group-sm" role="group" aria-label="...">
       <a href="/view_zfs_pools" role="button" class="btn btn-default"> Cancel</a>&nbsp;&nbsp;
-      <button type="submit" class="btn btn-primary cover-page">Import </button>
+      <button type="submit" class="btn btn-primary cover-page"  {% if not form.name %} disabled {% endif %}>Import </button>
     </div>
   </form>
 {%endblock%}
@@ -30,7 +50,7 @@
 {%endblock%}
 
 {%block help_body%}
-  <p>Use this screen to import a ZFS pool from the data disks that has been previously exported. If successfully imported, the pool will show up in the list of pools.</p>
+  <p>Use this screen to import a ZFS pool from the data disks that has been previously exported/destroyed. If successfully imported, the pool will show up in the list of pools.</p>
 {%endblock%}
 
 {% block tab_active %}

--- a/integral_view/views/zfs_management.py
+++ b/integral_view/views/zfs_management.py
@@ -379,12 +379,18 @@ def import_all_zfs_pools(request):
 def import_zfs_pool(request):
     return_dict = {}
     try:
+        exported_pools, err = zfs.get_exported_pool_names()
+        if err:
+            raise Exception(err)
+        destroyed_pools, err = zfs.get_exported_pool_names(get_destroyed=True)
+        if err:
+            raise Exception(err)
         if request.method == 'GET':
-            form = zfs_forms.ImportPoolForm()
+            form = zfs_forms.ImportPoolForm(exported_pools=exported_pools, destroyed_pools=destroyed_pools)
             return_dict['form'] = form
             return django.shortcuts.render_to_response("import_zfs_pool.html", return_dict, context_instance=django.template.context.RequestContext(request))
         else:
-            form = zfs_forms.ImportPoolForm(request.POST)
+            form = zfs_forms.ImportPoolForm(request.POST, exported_pools=exported_pools, destroyed_pools=destroyed_pools)
             return_dict['form'] = form
             if not form.is_valid():
                 return django.shortcuts.render_to_response("import_zfs_pool.html", return_dict, context_instance=django.template.context.RequestContext(request))


### PR DESCRIPTION
 - List pool names available for importing
 - Include destroyed pools as well

Users previously had no means of knowing available pools that can be
imported. Options were there to either provide a pool name or import
all pools without being aware of what is available.
If a pool was accidently destroyed, there was no means to import it
back.

Signed-off-by: six-k <ramsri.hp@gmail.com>