### PR TITLE
Small enhancements to the alerting icon and links

### DIFF
--- a/integral_view/templates/logged_in_base.html
+++ b/integral_view/templates/logged_in_base.html
@@ -19,16 +19,15 @@
 
 
     <script type="text/javascript">
-      function get_alerts(){
+      function check_alerts(){
         $.get('/refresh_alerts/',function(data){
-          $.each(data,function(){
-            var alerts = $.parseJSON(JSON.stringify(this));
+          if (data == true) {
             $("#alerts_icon").removeClass("white").addClass("yellow faa-flash animated");
-          });
+          }
         });
       }
-      var auto_refresh = setInterval(function (){get_alerts()}, 20000);
-      get_alerts()
+      var auto_refresh = setInterval(function (){check_alerts()}, 20000);
+      check_alerts();
     </script>
 
     {%block header_scripts%}

--- a/integral_view/templates/logged_in_base.html
+++ b/integral_view/templates/logged_in_base.html
@@ -157,7 +157,7 @@
                 </a>
               </li>
               <li id="logging_menu">
-                <a href="/view_alerts/">
+                <a href="/view_audits/">
                   <i class="fa fa-file"></i> Monitoring
                 </a>
               </li>

--- a/integral_view/templates/logging_base.html
+++ b/integral_view/templates/logging_base.html
@@ -1,11 +1,11 @@
 {% extends 'logged_in_base.html' %}
 
 {%block tab_items %}
-  <li id="alerts_tab">
-    <a href="/view_alerts">Alerts</a>
-  </li>
   <li id="audits_tab">
     <a href="/view_audits">Audit trail</a>
+  </li>
+  <li id="alerts_tab">
+    <a href="/view_alerts">Alerts</a>
   </li>
   <li id="logs_tab">
     <a href="/download_log">Logs</a>

--- a/integral_view/views/log_management.py
+++ b/integral_view/views/log_management.py
@@ -306,12 +306,7 @@ def refresh_alerts(request, random=None):
             raise Exception(err)
         if new_alerts_present:
             import json
-            alerts_list, err = alerts.get_alerts()
-            if err:
-                raise Exception(err)
-            if not alerts_list:
-                raise Exception('Error loading alerts')
-            new_alerts = json.dumps([dict(alert=pn) for pn in alerts_list])
+            new_alerts = json.dumps(new_alerts_present)
             return django.http.HttpResponse(new_alerts, content_type='application/json')
         else:
             clss = "btn btn-default btn-sm"


### PR DESCRIPTION
The refresh for new alerts was loading all alerts each time so changed it to only check for new alerts. Also changed the monitoring link to load the audits instead of the alerts screen in case there are too many alerts and the screen takes very long to load as a result.