### PR TITLE
Reset/delete network interface connection profile

### DIFF
--- a/integral_view/templates/delete_interface_connection_conf.html
+++ b/integral_view/templates/delete_interface_connection_conf.html
@@ -1,0 +1,35 @@
+{% extends 'networking_base.html' %}
+
+{%block tab_header %}
+  Reset connection configuration of '{{name}}' - confirmation
+{%endblock%}
+
+{%block inside_content%}
+
+  <p id="p-warning-text">Are you sure you want to reset the address configuration of network interface '{{name}}'?  This will potentially result in a disruption of usage of the system.</p>
+  <br>
+  <form action="/delete_interface_connection/" method="POST">
+    {%csrf_token%}
+    <input type=hidden name="name" value="{{name}}">
+    <div class="btn-group btn-group-sm" role="group" aria-label="...">
+      <input type="button" class="btn btn-default" value="Cancel" onClick="window.location='/view_interface?name={{name}}'"> &nbsp;&nbsp;
+      <button type="submit" class="btn btn-primary" onClick ="$('#processing').modal('show');">Confirm and continue </button>
+    </div>
+  </form>
+
+{%endblock%}
+
+{%block help_header%}
+  Reset NIC's address configuration
+{%endblock%}
+
+{%block help_body%}
+  <p>Confirming this operation will reset the address configuration of the specified interface in the system. Please ensure that this is actually intended before continuing.</p>
+{%endblock%}
+
+{% block tab_active%}
+  <script>
+    make_tab_active("view_interfaces_tab")
+  </script>
+{% endblock %}
+

--- a/integral_view/templates/view_interface.html
+++ b/integral_view/templates/view_interface.html
@@ -16,13 +16,13 @@
           {%endif%}
           {% if not nic.slave_to %}
             <li><a class="action-dropdown" href="/update_interface_address?name={{name}}" ><i class="fa fa-cog fa-fw"></i>&nbsp;Modify interface address..</a></li>
-          {%endif%}
-          {%if not nic.vlan %}
+          {%if not nic.vlan  and 'AF_INET' in nic.addresses  or nic.bootproto == 'dhcp' or nic.addresses.is_sysd_ip4 == True %}
             {%if nic.up_status == 'up' %}
               <li><a class="action-dropdown" href="/update_interface_state?name={{name}}&state=down" class="color:red"><i class="fa fa-stop-circle-o fa-fw"></i>&nbsp;Bring down this interface</a></li>
             {%else %}
               <li><a class="action-dropdown" href="/update_interface_state?name={{name}}&state=up" ><i class="fa fa-play-circle-o fa-fw"></i>&nbsp;Bring up this interface</a></li>
             {%endif%}
+          {%endif%}
           {%endif%}
           <li><a class="action-dropdown" href="/create_vlan?nic={{name}}" role="button" ><i class="fa fa-plus fa-fw"></i>&nbsp;Create a VLAN</a></li>
         {%endif%}

--- a/integral_view/templates/view_interfaces.html
+++ b/integral_view/templates/view_interfaces.html
@@ -58,17 +58,18 @@
                   <a class="btn btn-default dropdown-toggle" data-toggle="dropdown" href="#" title="Click for interface specific actions"> <i class="fa fa-cog fa-fw"></i>Actions&nbsp;<span class="fa fa-caret-down" title="Toggle dropdown menu"></span> </a>
                   <ul class="dropdown-menu">
                     <li><a class="action-dropdown" href="/view_interface?name={{name}}"> <i class="fa fa-cog fa-fw"></i>&nbsp;View details and configure</a></li>
-                    {% if not d.slave_to %}
-                      <li><a class="action-dropdown" href="/update_interface_address?name={{name}}" ><i class="fa fa-exchange fa-fw"></i>&nbsp;Edit interface address..</a></li>
-                    {%endif%}
                     {%if not d.vlan %}
-                      <!--
+                    {% if 'AF_INET' in d.addresses  or d.bootproto == 'dhcp' or d.addresses.is_sysd_ip4 == True%}
                       {%if d.up_status == 'up' %}
                         <li><a class="action-dropdown" href="/update_interface_state?name={{name}}&state=down" style="color:red"><i class="fa fa-stop-circle fa-fw"></i>&nbsp;Bring down this interface</a></li>
                       {%else %}
                         <li><a class="action-dropdown" href="/update_interface_state?name={{name}}&state=up"><i class="fa fa-play-circle fa-fw"></i>&nbsp;Bring up this interface</a></li>
                       {%endif%}
-                      -->
+                      <li><a class="action-dropdown" href="/delete_interface_connection?name={{name}}" style="color:red"><i class="fa fa-trash fa-fw"></i>&nbsp;Reset connection configuration..</a></li>
+                      {%endif%}
+                    {% if not d.slave_to %}
+                      <li><a class="action-dropdown" href="/update_interface_address?name={{name}}" ><i class="fa fa-exchange fa-fw"></i>&nbsp;Edit interface address..</a></li>
+                    {%endif%}
                     {%endif%}
                   </ul>
                 </div>

--- a/integral_view/urls.py
+++ b/integral_view/urls.py
@@ -28,7 +28,7 @@ from integral_view.views.nfs_share_management import view_nfs_shares, view_nfs_s
 
 from integral_view.views.zfs_management import view_zfs_pools, view_zfs_pool, view_zfs_dataset, update_zfs_dataset, delete_zfs_dataset, create_zfs_dataset, view_zfs_snapshots, create_zfs_snapshot, delete_zfs_snapshot, delete_all_zfs_snapshots, rename_zfs_snapshot, rollback_zfs_snapshot, create_zfs_pool, delete_zfs_pool, update_zfs_slog, delete_zfs_slog, scrub_zfs_pool, clear_zfs_pool, create_zfs_zvol, view_zfs_zvol, import_all_zfs_pools, create_zfs_spares, delete_zfs_spare, expand_zfs_pool, delete_zfs_quota, update_zfs_quota, export_zfs_pool, import_zfs_pool, schedule_zfs_snapshot, update_zfs_l2arc, delete_zfs_l2arc, view_zfs_snapshot_schedules, update_zfs_dataset_advanced_properties, api_get_pool_usage_stats, view_zfs_historical_usage
 
-from integral_view.views.networking_management import view_interfaces, view_interface, view_bond, update_interface_state, update_interface_address, create_bond, delete_bond, view_hostname, update_hostname, view_dns_nameservers, update_dns_nameservers, delete_vlan, create_vlan
+from integral_view.views.networking_management import view_interfaces, view_interface, view_bond, update_interface_state, update_interface_address, delete_interface_connection, create_bond, delete_bond, view_hostname, update_hostname, view_dns_nameservers, update_dns_nameservers, delete_vlan, create_vlan
 
 from integral_view.views.services_management import view_services, update_service_status
 
@@ -194,6 +194,8 @@ urlpatterns = patterns('',
                        url(r'^view_bond/', login_required(view_bond)),
                        url(r'^update_interface_address/',
                            login_required(update_interface_address)),
+                       url(r'^delete_interface_connection/',
+                           login_required(delete_interface_connection)),
                        url(r'^create_vlan/', login_required(create_vlan)),
                        url(r'^delete_vlan/', login_required(delete_vlan)),
                        url(r'^create_bond/', login_required(create_bond)),

--- a/site-packages/integralstor/audit.py
+++ b/site-packages/integralstor/audit.py
@@ -158,6 +158,7 @@ def _parse_audit_entry(entry):
             "change_service_status": "Service status modified",
             "set_interface_state": "Network interface state modified",
             "edit_interface_address": "Network interface address modified",
+            "delete_interfaces_connection": "Reset address configuration of network interface",
             "create_bond": "Network interface bond created",
             "remove_bond": "Network interface bond removed",
             "edit_hostname": "System hostname modified",

--- a/site-packages/integralstor/networking.py
+++ b/site-packages/integralstor/networking.py
@@ -255,10 +255,6 @@ def delete_bond(bond_name):
                 if err:
                     raise Exception(err)
 
-                if not os.path.isfile('/etc/sysconfig/network-scripts/ifcfg-%s' % slave):
-                    with open('/etc/sysconfig/network-scripts/ifcfg-%s' % slave, 'w') as f:
-                        pass
-
             ret, err = restart_networking()
             if not ret:
                 if err:
@@ -365,6 +361,7 @@ def delete_interfaces_connection(if_name=None):
     """
 
     error_list = []
+    is_delete = False
     try:
         init_type, err = config.get_init_type()
         if err:
@@ -379,22 +376,24 @@ def delete_interfaces_connection(if_name=None):
             raise Exception(err)
         if if_name and interfaces and if_name not in interfaces:
             raise Exception('Invalid interface')
-        for if_name in interfaces.keys():
-            if not interfaces[if_name]['addresses']['is_sysd_ip4']:
-                error_list.append('Interface not part of NetworkManager')
+        for iface in interfaces.keys():
+            if if_name and if_name != iface:
+                continue
+            if not interfaces[iface]['addresses']['is_sysd_ip4']:
+                error_list.append('Interface %s is not part of NetworkManager' % iface)
                 continue
 
-            cmd_iface = 'nmcli con delete %s' % (if_name)
+            cmd_iface = 'nmcli con delete %s' % (iface)
             r, err = command.get_command_output(cmd_iface)
             if err:
                 error_list.append(err)
-
-            if not os.path.isfile('/etc/sysconfig/network-scripts/ifcfg-%s' % if_name):
-                with open('/etc/sysconfig/network-scripts/ifcfg-%s' % if_name, 'w') as f:
-                    pass
+            is_delete = True
 
         # Best effort service restart
-        ret, err = restart_networking()
+        if is_delete == True:
+            ret, err = restart_networking()
+        else:
+            error_list.append('Interface %s is not available; did not delete. If the interface is down, please retry after bringing it up.' % if_name)
         if error_list:
             raise Exception(str(error_list))
 
@@ -1695,7 +1694,8 @@ if __name__ == "__main__":
     # print delete_all_bonds()
     # print delete_interface_connection('eno67109432')
     # print delete_interfaces_connection()
-    print default_ip_on_next_boot()
+    # print default_ip_on_next_boot()
+    print delete_interfaces_connection(if_name='eth1')
 
 
 # vim: tabstop=8 softtabstop=0 expandtab ai shiftwidth=4 smarttab


### PR DESCRIPTION
    - If any non-slave interface is configured, allow the address
      to be reset by deleting it
    - If the address is configured and the interface is not a slave,
      allow it to be brought up/down(state change)
    - Does not allow a reset if the interface is down

Addresses #226

Signed-off-by: six-k <ramsri.hp@gmail.com>