### PR TITLE
 Fix disk entries of master.status

### DIFF
--- a/site-packages/integralstor/manifest_status.py
+++ b/site-packages/integralstor/manifest_status.py
@@ -517,8 +517,8 @@ def generate_status_info(path):
             # print disk_sn
             dd = {}
             if disk_sn in disk_status_dict.keys():
-                dd["name"] = disk_status_dict[disk_sn]["name"]
-                dd["status"] = disk_status_dict[disk_sn]["status"]
+                for k in disk_status_dict[disk_sn].keys():
+                    dd[k] = disk_status_dict[disk_sn][k]
                 if dd['status']:
                     if ('hw_raid' not in disk_info_dict) or (not disk_info_dict['hw_raid']):
                         if (dd["status"].lowed() not in ['ok', 'passed']):


### PR DESCRIPTION
The dict returned by disks.get_disk_status() contain keys 'scsi_info'
and 'partitions' but they weren't added to the master.status json.

Addresses: #358
Signed-off-by: six-k <ramsri.hp@gmail.com>