### PR TITLE
Inlcude write perm for group on creating a new FS

### DIFF
--- a/site-packages/integralstor/zfs.py
+++ b/site-packages/integralstor/zfs.py
@@ -1086,7 +1086,7 @@ def create_dataset(parent, ds_name, properties):
 
         os.chown('/%s' % path, -1, owner_gid)
         os.chmod('/%s' % path, stat.S_IWUSR | stat.S_IRUSR | stat.S_IXUSR |
-                 stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH | stat.S_ISGID)
+                 stat.S_IRGRP | stat.S_IWGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH | stat.S_ISGID)
         os.system('setfacl -d -m g::rwx /%s' % path)
         os.system('setfacl -d -m o::rx /%s' % path)
     except Exception, e:


### PR DESCRIPTION
This allows rsync to control the directory contents through replicator
user since replicator user is part of integralstor group

Signed-off-by: six-k <ramsri.hp@gmail.com>