### PR TITLE
Fix SSH related params for rsync

### DIFF
--- a/scripts/shell/rsync_replicator.sh
+++ b/scripts/shell/rsync_replicator.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # set -o xtrace
 rsync_cmd=$1
 rename_snap=$2

--- a/site-packages/integralstor/pki.py
+++ b/site-packages/integralstor/pki.py
@@ -393,9 +393,9 @@ def get_ssh_key(user='replicator'):
 
 def get_ssh_host_identity_key():
     try:
-        shutil.copyfile("/etc/ssh/ssh_host_rsa_key.pub",
-                        "/opt/integralstor/integralstor/integral_view/static/ssh_host_rsa_key.pub")
-        return "ssh_host_rsa_key.pub", None
+        shutil.copyfile("/etc/ssh/ssh_host_ecdsa_key.pub",
+                        "/opt/integralstor/integralstor/integral_view/static/ssh_host_ecdsa_key.pub")
+        return "ssh_host_ecdsa_key.pub", None
     except Exception, e:
         return False, "Error generating public key file: %s" % str(e)
 

--- a/site-packages/integralstor/remote_replication.py
+++ b/site-packages/integralstor/remote_replication.py
@@ -732,8 +732,8 @@ def run_rsync_remote_replication(remote_replication_id):
 
         cmd_arg = ''
         if rsync_type in ['push', 'pull']:
-            cmd_arg = 'sudo rsync -hiOP %s %s --stats -e \\"ssh -l replicator -i /home/replicator/.ssh/id_rsa -o ServerAliveInterval=300 -o ServerAliveCountMax=3\\" %s %s' % (
-                short_switches, long_switches, source, target)
+            cmd_arg = 'sudo rsync -hiOP %s %s --stats -e \\"ssh -l %s -i /home/%s/.ssh/id_rsa -o UserKnownHostsFile=/home/%s/.ssh/known_hosts -o ServerAliveInterval=300 -o ServerAliveCountMax=3\\" %s %s' % (
+                short_switches, long_switches, run_as_user_name, run_as_user_name, run_as_user_name, source, target)
         elif rsync_type in ['local']:
             cmd_arg = 'rsync -hiOP %s %s --stats %s %s' % (
                 short_switches, long_switches, source, target)


### PR DESCRIPTION
#### Update host identification key of SSH

OpenSSH_7.4p1 asks for ECDSA host key; this was RSA in the earlier
version.

Signed-off-by: six-k <ramsri.hp@gmail.com>

#### Specify known_hosts file path

While connecting through SSH for rsync, provide the known_hosts
file path for that replication user(replicator).

Signed-off-by: six-k <ramsri.hp@gmail.com>