### PR TITLE
Add ability to terminate replication task

### DIFF
--- a/install/scripts/configure_os.sh
+++ b/install/scripts/configure_os.sh
@@ -62,10 +62,13 @@ mkdir -p /opt/integralstor/integralstor/config/db
 mkdir -p /opt/integralstor/integralstor/config/status
 mkdir -p /opt/integralstor/integralstor/config/pki
 mkdir -p /opt/integralstor/integralstor/config/conf_files
+mkdir -p /opt/integralstor/integralstor/config/run
+mkdir -p /opt/integralstor/integralstor/config/run/tasks
 
 chmod -R 777 /var/log/integralstor
 chmod -R 755 /opt/integralstor/integralstor/scripts/python/*
 chmod -R 755 /opt/integralstor/integralstor/scripts/shell/*
+chmod -R 775 /opt/integralstor/integralstor/config/run
 
 touch /var/log/integralstor/logs/scripts/scripts.log
 touch /var/log/integralstor/logs/scripts/integral_view.log

--- a/integral_view/templates/view_task_details.html
+++ b/integral_view/templates/view_task_details.html
@@ -9,6 +9,10 @@
       <a class="btn btn-default dropdown-toggle" data-toggle="dropdown" href="#"> <i class="fa fa-cog fa-fw"></i>&nbsp;Actions &nbsp;<span class="fa fa-caret-down" title="Toggle dropdown menu"></span> </a>
       <ul class="dropdown-menu">
         <li><a class="action-dropdown" href="/view_background_tasks/" ><i class="fa fa-list fa-fw"></i>&nbsp;Back to tasks list</a></li>
+        {% if task.status == "running" %}
+        <li class="divider"></li>
+        <li><a class="action-dropdown" href="/stop_background_task?task_id={{task.task_id}}" style="color:red"> <i class="fa fa-cog fa-fw"></i>&nbsp;Stop this task </a></li>
+        {% endif %}
         <li class="divider"></li>
         <li><a class="action-dropdown" href="/delete_background_task?task_id={{task.task_id}}" style="color:red"> <i class="fa fa-trash fa-fw"></i>&nbsp;Remove this task </a></li>
       </ul>

--- a/integral_view/urls.py
+++ b/integral_view/urls.py
@@ -2,7 +2,7 @@ from django.conf.urls import patterns, include, url
 
 from integral_view.views.monitoring import view_read_write_stats, api_get_status, view_remote_monitoring_servers, update_remote_monitoring_server, delete_remote_monitoring_server, view_remote_monitoring_server_status, view_scheduled_notifications, create_scheduled_notification, delete_scheduled_notification
 
-from integral_view.views.scheduler_cron_management import view_background_tasks, view_task_details, delete_background_task
+from integral_view.views.task_management import view_background_tasks, view_task_details, delete_background_task, stop_background_task
 
 from integral_view.views.disk_management import view_disks, identify_disk, replace_disk
 
@@ -255,11 +255,13 @@ urlpatterns = patterns('',
                        url(r'^delete_rsync_share',
                            login_required(delete_rsync_share)),
 
-                       # From views/scheduler_cron_management.py
+                       # From views/task_management.py
                        url(r'^view_background_tasks/',
                            login_required(view_background_tasks)),
                        url(r'^delete_background_task/',
                            login_required(delete_background_task)),
+                       url(r'^stop_background_task/',
+                           login_required(stop_background_task)),
                        url(r'^view_task_details/([0-9]*)',
                            login_required(view_task_details)),
 

--- a/scripts/shell/rsync_replicator.sh
+++ b/scripts/shell/rsync_replicator.sh
@@ -1,10 +1,18 @@
 #!/bin/bash
 # set -o xtrace
+
 rsync_cmd=$1
 rename_snap=$2
 create_snap=$3
-# echo $rsync_cmd
+rr_id=$4
 exit_code=""
+# echo $rsync_cmd
+
+# get the process group id of this process
+pgid=$(ps -o pgid= $$ | grep -o [0-9]*)
+
+# store the process group id
+printf '%s' "$pgid" > /opt/integralstor/integralstor/config/run/tasks/rr."$rr_id".pgid
 
 echo "$rsync_cmd" | /bin/bash
 rsync_rc=$?
@@ -33,6 +41,9 @@ if (( "$exit_code"=="0" )); then
     echo "Could not sync snapshots"
   fi
 fi
+
+# remove the process group id file
+rm -f /opt/integralstor/integralstor/config/run/tasks/rr."$rr_id".pgid
 
 exit $exit_code
 

--- a/site-packages/integralstor/audit.py
+++ b/site-packages/integralstor/audit.py
@@ -192,6 +192,7 @@ def _parse_audit_entry(entry):
             "edit_rsync_share": "Edited RSync share ",
             "delete_rsync_share": "Deleted RSync share ",
             "remove_background_task": "Removed background task ",
+            "stop_background_task": "Stopped background task ",
             "create_remote_replication": "Created remote replication ",
             "modify_remote_replication": "Modified remote replication ",
             "remove_remote_replication": "Removed remote replication ",

--- a/site-packages/integralstor/config.py
+++ b/site-packages/integralstor/config.py
@@ -191,6 +191,42 @@ def get_version():
         return version, None
 
 
+def get_run_dir():
+    """The directory where process related info is stored.
+
+    """
+    ret = None
+    try:
+        config_dir, err = get_config_dir()
+        if err:
+            raise Exception(err)
+        if not config_dir:
+            raise Exception('Could not retrieve configuration directory')
+        ret = "%s/run" % config_dir
+    except Exception, e:
+        return None, "Error retrieving run location : %s" % str(e)
+    else:
+        return ret, None
+
+
+def get_tasks_pgid_dir():
+    """Dir where process related info relevant to scheduled tasks is stored
+
+    """
+    ret = None
+    try:
+        run_dir, err = get_run_dir()
+        if err:
+            raise Exception(err)
+        if not run_dir:
+            raise Exception('Could not retrieve run directory')
+        ret = "%s/tasks" % run_dir
+    except Exception, e:
+        return None, "Error retrieving tasks pgid location : %s" % str(e)
+    else:
+        return ret, None
+
+
 def get_pki_dir():
     """The directory where SSL certs and keys are stored. """
     ret = None
@@ -609,7 +645,8 @@ def main():
     # print get_system_uid_gid('integralstor', type = 'user')
     # print get_minimum_user_uid_gid('user')
     # print get_normal_users()
-    print get_urbackup_db_path()
+    # print get_urbackup_db_path()
+    print get_tasks_pgid_dir()
 
 
 if __name__ == "__main__":

--- a/site-packages/integralstor/remote_replication.py
+++ b/site-packages/integralstor/remote_replication.py
@@ -739,8 +739,8 @@ def run_rsync_remote_replication(remote_replication_id):
                 short_switches, long_switches, source, target)
 
         path = '%s/rsync_replicator.sh' % scripts_path
-        cmd = '/bin/bash %s "%s" "%s" "%s"' % (path,
-                                               cmd_arg, rename_snap_cmd, create_snap_cmd)
+        cmd = '/bin/bash %s "%s" "%s" "%s" "%s"' % (path,
+                                                    cmd_arg, rename_snap_cmd, create_snap_cmd, remote_replication_id)
 
         # Retry upto 3 times(default) with a retry interval of 1 hour
         ret, err = tasks_utils.create_task(description, [

--- a/site-packages/integralstor/scheduler_utils.py
+++ b/site-packages/integralstor/scheduler_utils.py
@@ -98,6 +98,7 @@ def get_cron_tasks(cron_task_id=None, user='root'):
             for cron_db_entry in cron_db_entries:
                 cron_dict = {}
                 cron_dict['description'] = cron_db_entry['description']
+                cron_dict['command'] = cron_db_entry['command']
                 cron_dict['cron_task_id'] = cron_db_entry['cron_task_id']
                 jobs = cron.find_comment(str(cron_db_entry['cron_task_id']))
                 if jobs:

--- a/site-packages/integralstor/tasks_utils.py
+++ b/site-packages/integralstor/tasks_utils.py
@@ -1,4 +1,4 @@
-from integralstor import config, db, command, audit
+from integralstor import config, db, command, audit, scheduler_utils
 
 import re
 import time
@@ -95,7 +95,16 @@ def create_task(description, subtask_list, task_type_id=0, cron_task_id=0, node=
 
 
 def delete_task(task_id):
+    """Terminate the task if it's running and delete the task entry
+
+    """
     try:
+        is_stopped, err = stop_task(task_id)
+        if err:
+            # best effort
+            # only remote replication tasks can be stopped(currently)
+            pass
+
         db_path, err = config.get_db_path()
         if err:
             raise Exception(err)
@@ -112,11 +121,119 @@ def delete_task(task_id):
         return True, None
 
 
+def get_task_pgid(task_id):
+    """Identify the process group id of this task
+
+    This action is applicable only for remote replication tasks(task_type_id=4)
+    """
+    pgid = ''
+    try:
+        pgid_dir_path, err = config.get_tasks_pgid_dir()
+        if err:
+            raise Exception(err)
+        task, err = get_task(task_id)
+        if err:
+            raise Exception(err)
+        cron_task_id = task['cron_task_id']
+        task_type_id = task['task_type_id']
+        if task_type_id != 4:
+            raise Exception("Not a remote replication task")
+        cron_entry, err = scheduler_utils.get_cron_tasks(cron_task_id)
+        if err:
+            raise Exception(err)
+        rr_cmd_str = str(cron_entry[0]['command']).strip()
+
+        # extract the remote replication id
+        rr_id = rr_cmd_str.split()[1]
+
+        pgid_file_path = '%s/rr.%s.pgid' % (pgid_dir_path, rr_id)
+        ret, err = command.get_command_output(
+            'cat %s' % pgid_file_path, shell=True)
+        if err:
+            raise Exception("Could not identify the process instance")
+
+        if ret and ret[0]:
+            pgid = ret[0]
+        else:
+            raise Exception("Could not identify the process instance")
+
+    except Exception, e:
+        return False, 'Error fetching pgid: %s' % e
+    else:
+        return pgid, None
+
+
+def stop_task(task_id):
+    """Terminate the process group of this task
+
+    This action is applicable only for remote replication tasks(task_type_id=4)
+    """
+    try:
+        # Since task_id is the only readily availble identifier, use that to
+        # retrieve relevant information. The only link between the task entry
+        # and its corresponding remote_replication entry is cron_task_id. The
+        # respective cron entry contains the remote_replication id embedded in
+        # its command field; extract that to identify the pgid file which will
+        # contain the process group id.
+        pgid, err = get_task_pgid(task_id)
+        print pgid
+        if err:
+            raise Exception(err)
+        cmd = 'kill -- -%s' % pgid
+        print cmd
+        ret, err = command.get_command_output(cmd, shell=True)
+        print ret
+        if err:
+            raise Exception("Could not terminate the process group: %s" % err)
+
+        task, err = get_task(task_id)
+        if err:
+            raise Exception(err)
+        attempts = task['attempts']
+        audit_str = "%s" % task['description']
+        status_update = ''
+
+        if attempts > 1:
+            status_update = "update tasks set status = 'error-retrying', attempts = %d where task_id = '%d' and status is not 'cancelled'" % (
+                attempts - 1, task['task_id'])
+        elif attempts == -2:
+            status_update = "update tasks set status = 'error-retrying', attempts = %d where task_id = '%d' and status is not 'cancelled'" % (
+                -2, task['task_id'])
+        else:
+            status_update = "update tasks set status = 'failed', attempts = '%d' where task_id = '%d' and status is not 'cancelled'" % (
+                0, task['task_id'])
+        db_path, err = config.get_db_path()
+        if err:
+            raise Exception(err)
+        status, err = db.execute_iud(
+            db_path, [[status_update], ], get_rowid=True)
+        if err:
+            raise Exception(err)
+
+        audit.audit("task_fail", audit_str,
+                    None, system_initiated=True)
+
+    except Exception, e:
+        return False, 'Error stopping task: %s' % e
+    else:
+        return True, None
+
+
 def delete_all_tasks():
-    """Delete all entries from tasks and subtasks table
+    """Delete all entries from tasks table and terminate running tasks
 
     """
     try:
+        tasks, err = get_tasks()
+        if err:
+            raise Exception(err)
+        for task in tasks:
+            if str(task['status']) == 'running':
+                ret, err = stop_task(int(task['task_id']))
+                if err:
+                    # best effort
+                    pass
+
         db_path, err = config.get_db_path()
         if err:
             raise Exception(err)
@@ -324,7 +441,7 @@ def process_tasks(node=socket.getfqdn()):
                             status_update = 'update subtasks set status = "error-retrying", return_code="%d" where subtask_id = "%d" and status is not "cancelled";' % (
                                 return_code, subtask_id)
                         elif attempts in [0, 1]:
-                            status_update = 'update scheduler_commands set status = "failed", return_code="%d"" where subtask_id = "%d" and status is not "cancelled";' % (
+                            status_update = 'update subtasks set status = "failed", return_code="%d"" where subtask_id = "%d" and status is not "cancelled";' % (
                                 return_code, subtask_id)
                         execute, err = db.execute_iud(
                             db_path, [[status_update], ], get_rowid=True)
@@ -367,7 +484,9 @@ def main():
     # get_tasks()
     # print delete_task(5)
     # print delete_all_tasks()
-    print is_task_running(1)
+    # print is_task_running(1)
+    print get_task_pgid(1)
+    print stop_task(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
If the replication process is underway(running), it can be terminated
from IV through /stop_background_task?task_id=

Also, inherently try to stop the process while a call to delete a
background task is made.

Note: Currently implemented only for rsync mode; will have to extend
for ZFS send/receive if this pans out effectively.

Addresses #212

Signed-off-by: six-k <ramsri.hp@gmail.com>