### PR TITLE
Disk replacement bug fix

### DIFF
--- a/integral_view/templates/replace_disk_choose_disk.html
+++ b/integral_view/templates/replace_disk_choose_disk.html
@@ -56,6 +56,6 @@
 
 {% block tab_active %}
   <script>
-    make_tab_active("view_disks_tab")
+    make_tab_active("view_data_disks_tab")
   </script>
 {% endblock %}

--- a/integral_view/templates/replace_disk_conf.html
+++ b/integral_view/templates/replace_disk_conf.html
@@ -32,6 +32,6 @@
 
 {% block tab_active %}
   <script>
-    make_tab_active("view_disks_tab")
+    make_tab_active("view_data_disks_tab")
   </script>
 {% endblock %}

--- a/integral_view/templates/replace_disk_confirm_new_disk.html
+++ b/integral_view/templates/replace_disk_confirm_new_disk.html
@@ -37,6 +37,6 @@
 
 {% block tab_active %}
   <script>
-    make_tab_active("view_disks_tab")
+    make_tab_active("view_data_disks_tab")
   </script>
 {% endblock %}

--- a/integral_view/templates/replace_disk_method.html
+++ b/integral_view/templates/replace_disk_method.html
@@ -41,6 +41,6 @@
 
 {% block tab_active %}
   <script>
-    make_tab_active("view_disks_tab")
+    make_tab_active("view_data_disks_tab")
   </script>
 {% endblock %}

--- a/integral_view/templates/replace_disk_offlined_conf.html
+++ b/integral_view/templates/replace_disk_offlined_conf.html
@@ -53,6 +53,6 @@
 
 {% block tab_active %}
   <script>
-    make_tab_active("view_disks_tab")
+    make_tab_active("view_data_disks_tab")
   </script>
 {% endblock %}

--- a/integral_view/templates/replace_disk_success.html
+++ b/integral_view/templates/replace_disk_success.html
@@ -21,6 +21,6 @@
 
 {% block tab_active %}
   <script>
-    make_tab_active("view_disks_tab")
+    make_tab_active("view_data_disks_tab")
   </script>
 {% endblock %}

--- a/site-packages/integralstor/manifest_status.py
+++ b/site-packages/integralstor/manifest_status.py
@@ -51,6 +51,29 @@ def get_disk_info(rescan=False):
         return return_dict, None
 
 
+def get_pool_on_disk(disk_id):
+    pool_name = None
+    try:
+        if disk_id:
+            pool_list, err = zfs.get_pools()
+            if pool_list:
+                found = False
+                for pool in pool_list:
+                    devices_list, err = zfs.get_disks_in_component(
+                        pool['config']['pool']['root'])
+                    if err:
+                        raise Exception(err)
+                    # print 'devices list is ', devices_list
+                    if devices_list and disk_id in devices_list:
+                        pool_name = pool['pool_name']
+                        break
+                        # print 'in devices list'
+    except Exception, e:
+        return None, 'Error updating pool information for disk : %s' % str(e)
+    else:
+        return pool_name, None
+
+
 def get_disk_status():
     return_dict = None
     try:
@@ -509,6 +532,7 @@ def generate_status_info(path):
         disks_dict = {}
         disk_status_dict, err = disks.get_disk_info_status_all(
             rescan=False, type='status')
+        #disk_status_dict, err = get_disk_status()
         if err:
             raise Exception(err)
         # print disk_status_dict.keys()
@@ -531,6 +555,10 @@ def generate_status_info(path):
                 status_dict["errors"].append(
                     {'subsystem_type_id': 1, 'severity_type_id': 3, 'component':  disk_sn, 'alert_str':
                      "Disk with serial number %s seems to be missing." % disk_sn})
+            pool_on_disk, err = get_pool_on_disk(disk_info_dict['id'])
+            if err:
+                raise Exception(err)
+            dd['pool'] = pool_on_disk
             disks_dict[disk_sn] = dd
             '''
             #Dont detect new disks here because it requires a costly disk rescan
@@ -729,6 +757,9 @@ def main():
     # pp.pprint(get_services_status())
     # pp.pprint(generate_manifest_info())
     # print ret, err
+    # pp.pprint(get_disk_status())
+    # pp.pprint(disks.get_disk_info_status_all(
+    #        rescan=False, type='status'))
     # print ret.keys()
     # pp.pprint(get_interface_status())
     # print zfs_version()
@@ -737,8 +768,8 @@ def main():
     # pp.pprint(generate_status_info(
     #    '/opt/integralstor/integralstor/config/status/master.manifest'))
     # pp.pprint(generate_status_info('/opt/integralstor/integralstor_gridcell/config/status/master.manifest'))
-    pp.pprint(generate_status_info(
-        '/opt/integralstor/integralstor/config/status/master.manifest'))
+    # pp.pprint(generate_status_info(
+    #    '/opt/integralstor/integralstor/config/status/master.manifest'))
     #r, err = generate_status_info('/opt/integralstor/integralstor/config/status/master.manifest')
     # print r, err
     # if err:


### PR DESCRIPTION
Fixed a bug in disk replacement that was caused by the splitting of the disk information and status. The status file did not contain the pool that the disk was part of and so on the screen, it resulted in a message saying that the disks was not part of a pool and could be replaced without the need for the wizard. This PR should fix that problem.