### PR TITLE
Check task status string before updating it

### DIFF
--- a/site-packages/integralstor/tasks_utils.py
+++ b/site-packages/integralstor/tasks_utils.py
@@ -176,39 +176,42 @@ def stop_task(task_id):
         # its command field; extract that to identify the pgid file which will
         # contain the process group id.
         pgid, err = get_task_pgid(task_id)
-        print pgid
         if err:
             raise Exception(err)
         cmd = 'kill -- -%s' % pgid
-        print cmd
         ret, err = command.get_command_output(cmd, shell=True)
-        print ret
         if err:
             raise Exception("Could not terminate the process group: %s" % err)
+        time.sleep(5)
 
         task, err = get_task(task_id)
         if err:
             raise Exception(err)
+        status = str(task['status'])
         attempts = task['attempts']
         audit_str = "%s" % task['description']
         status_update = ''
 
-        if attempts > 1:
-            status_update = "update tasks set status = 'error-retrying', attempts = %d where task_id = '%d' and status is not 'cancelled'" % (
-                attempts - 1, task['task_id'])
-        elif attempts == -2:
-            status_update = "update tasks set status = 'error-retrying', attempts = %d where task_id = '%d' and status is not 'cancelled'" % (
-                -2, task['task_id'])
-        else:
-            status_update = "update tasks set status = 'failed', attempts = '%d' where task_id = '%d' and status is not 'cancelled'" % (
-                0, task['task_id'])
-        db_path, err = config.get_db_path()
-        if err:
-            raise Exception(err)
-        status, err = db.execute_iud(
-            db_path, [[status_update], ], get_rowid=True)
-        if err:
-            raise Exception(err)
+        # If the caller(in fn process_tasks()) had not received a return code(
+        # term signal 9?), status is not updated and remains 'running', so,
+        # handle it here.
+        if status == 'running':
+            if attempts > 1:
+                status_update = "update tasks set status = 'error-retrying', attempts = %d where task_id = '%d' and status is not 'cancelled'" % (
+                    attempts - 1, task['task_id'])
+            elif attempts == -2:
+                status_update = "update tasks set status = 'error-retrying', attempts = %d where task_id = '%d' and status is not 'cancelled'" % (
+                    -2, task['task_id'])
+            else:
+                status_update = "update tasks set status = 'failed', attempts = '%d' where task_id = '%d' and status is not 'cancelled'" % (
+                    0, task['task_id'])
+            db_path, err = config.get_db_path()
+            if err:
+                raise Exception(err)
+            status, err = db.execute_iud(
+                db_path, [[status_update], ], get_rowid=True)
+            if err:
+                raise Exception(err)
 
         audit.audit("task_fail", audit_str,
                     None, system_initiated=True)
@@ -485,8 +488,10 @@ def main():
     # print delete_task(5)
     # print delete_all_tasks()
     # print is_task_running(1)
-    print get_task_pgid(1)
-    print stop_task(1)
+    # print get_task_pgid(1)
+    # print stop_task(1)
+    task, err = get_task(18)
+    print task, err
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Though the task status remains 'running' when its process group is
killed with a term signal, it's better to check the status string value
before proceeding with the update.

Signed-off-by: six-k <ramsri.hp@gmail.com>