### PR TITLE
Fix system datetime update

### DIFF
--- a/site-packages/integralstor/datetime_utils.py
+++ b/site-packages/integralstor/datetime_utils.py
@@ -9,11 +9,20 @@ import subprocess
 def get_tz_updated_env():
     env = None
     try:
-        tz_dict, err = get_system_timezone()
-        if err:
-            raise Exception(err)
-        if tz_dict and 'timezone_str' in tz_dict:
-            tz = tz_dict['timezone_str']
+        tz = None
+        tz_str = os.path.realpath('/etc/localtime')
+        if not tz_str:
+            raise Exception("Error getting timezone string")
+        if 'utc' in tz_str.lower():
+            tz = 'UTC'
+        else:
+            components = tz_str.split('/')
+            if components:
+                tz = '%s/%s' % (
+                    components[-2], components[-1])
+            else:
+                raise Exception("Error getting timezone string")
+
         env = os.environ.copy()
         env['TZ'] = tz
     except Exception, e:
@@ -30,6 +39,10 @@ def get_command_output(cmd, shell=False):
         if not cmd:
             raise Exception('No command supplied')
 
+        env, err = get_tz_updated_env()
+        if err:
+            raise Exception(err)
+
         if shell:
             comm_list = cmd
         else:
@@ -39,7 +52,7 @@ def get_command_output(cmd, shell=False):
             # print 'comm_list is ', comm_list
 
         proc = subprocess.Popen(
-            comm_list, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=shell)
+            comm_list, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=shell, env=env)
         ret = proc.communicate()
 
         if proc:
@@ -101,60 +114,51 @@ def convert_from_epoch(secs, return_format='datetime', str_format='%c', to='loca
 def update_system_date_time(system_date, system_time, system_timezone):
     return_dict = {}
     try:
-        if system_timezone == None:
-            pass
-        else:
+        if system_timezone is not None:
             cmd = 'timedatectl set-timezone %s' % system_timezone
-            # print cmd
-            output, err = get_command_output(cmd)
+            ret, err = get_command_output(cmd, shell=True)
             if err:
                 raise Exception(err)
             return_dict['timezone_set'] = True
             return_dict['timezone_set_to'] = system_timezone
 
-        if system_time == None:
-            pass
-        else:
-            tz, err = get_system_timezone()
+        if system_time is not None:
+            unset_ntp = 'timedatectl set-ntp false'
+            ret, err = get_command_output(unset_ntp, shell=True)
             if err:
-                raise Exception(err)
-            if 'system_timezone_code' in tz:
-                cmd = 'date -s "%s %s"' % (system_time,
-                                           tz['system_timezone_code'])
-            else:
-                cmd = 'date -s "%s"' % system_time
-            output, err = get_command_output(cmd)
+                raise Exception("Could not disable NTP sync")
+
+            cmd = 'timedatectl set-time %s' % system_time
+            ret, err = get_command_output(cmd, shell=True)
             if err:
                 raise Exception(err)
             return_dict['time_set'] = True
             return_dict['time_set_to'] = system_time
 
-        if system_date == None:
-            pass
-        else:
+        if system_date is not None:
+            unset_ntp = 'timedatectl set-ntp false'
+            ret, err = get_command_output(unset_ntp, shell=True)
+            if err:
+                raise Exception("Could not disable NTP sync")
+
             date_component = system_date.split("/")
             if len(date_component) != 3:
                 raise Exception(
                     "The input date format is not correct (Ex: MM/DD/YYYY)")
             system_date = '%s-%s-%s' % (date_component[2],
                                         date_component[0], date_component[1])
-            output_time, err = get_command_output("date +%T")
+            time_str, err = get_command_output("date +%T", shell=True)
             if err:
                 raise Exception(err)
-            cmd = 'date -s "%s %s"' % (system_date, output_time[0])
-            output, err = get_command_output(cmd)
+            cmd = "timedatectl set-time '%s %s'" % (system_date, time_str.strip())
+            ret, err = get_command_output(cmd, shell=True)
             if err:
                 raise Exception(err)
             return_dict['date_set'] = True
             return_dict['date_set_to'] = system_date
 
-        cmd = "hwclock -w"
-        output, err = get_command_output(cmd)
-        if err:
-            raise Exception(err)
-
     except Exception, e:
-        return None, 'Error setting date and time : %s' % str(e)
+        return None, 'Error updating date/time/timezone: %s' % str(e)
     else:
         return return_dict, None
 
@@ -223,7 +227,15 @@ def main():
 
 
 if __name__ == '__main__':
+    """
     print get_system_timezone()
+    output_time, err = get_command_output("date +%T", shell=True)
+    print output_time
+    print output_time.strip()
+    print get_tz_updated_env()
+    """
+    print get_system_timezone()
+    print get_tz_updated_env()
     pass
 
 # vim: tabstop=8 softtabstop=0 expandtab ai shiftwidth=4 smarttab


### PR DESCRIPTION
 - Use only timedatectl for all datetime related updates.
 - Disable NTP sync before date/time update; can't update when sync is
   enabled
 - Pass the TZ environment variable(as a follow up of #374)

Addreses #348
Signed-off-by: six-k <ramsri.hp@gmail.com>