### PR TITLE
Truncate tasks logs to the last 200 lines

### DIFF
--- a/site-packages/integralstor/tasks_utils.py
+++ b/site-packages/integralstor/tasks_utils.py
@@ -78,7 +78,8 @@ def create_task(description, subtask_list, task_type_id=0, cron_task_id=0, node=
             log_file = '%s/%d.log' % (log_dir, row_id)
             for subtask in subtask_list:
                 for description, command in subtask.iteritems():
-                    command = '%s  &> %s' % (command, log_file)
+                    # command = '%s  &> %s' % (command, log_file)
+                    command = '%s &> %s; tail -n 200 %s > %s.TMP && mv %s.TMP %s' % (command, log_file, log_file, log_file, log_file, log_file)
                     cmd = "insert into subtasks (description,command,task_id) values ('%s','%s','%d');" % (
                         description, command, row_id)
                     status, err = db.execute_iud(


### PR DESCRIPTION
Replication task log tends to grow enormously, truncate.

Signed-off-by: six-k <ramsri.hp@gmail.com>