### PR TITLE
Introduce pause schedule & fix task processing

### DIFF
--- a/install/conf-files/db/integralstor_db.schema
+++ b/install/conf-files/db/integralstor_db.schema
@@ -106,7 +106,8 @@ INSERT INTO cron_tasks (cron_task_id, description, command) values (-1, 'Dummy e
 CREATE TABLE "remote_replications" (
   "remote_replication_id" integer NOT NULL PRIMARY KEY AUTOINCREMENT,
   "mode" varchar(20) NOT NULL,
-  "cron_task_id" integer NOT NULL REFERENCES cron_tasks(cron_task_id) ON DELETE CASCADE
+  "cron_task_id" integer NOT NULL REFERENCES cron_tasks(cron_task_id) ON DELETE CASCADE,
+  "pause_cron_task_id" integer NOT NULL DEFAULT -1 REFERENCES cron_tasks(cron_task_id)
 );
 
 

--- a/integral_view/templates/update_remote_replication_pause_schedule.html
+++ b/integral_view/templates/update_remote_replication_pause_schedule.html
@@ -1,0 +1,217 @@
+{% extends 'snapshot_replication_base.html' %}
+
+{%block tab_header %}
+  Remote replication
+{%endblock%}
+
+{%block global_actions %}
+    <div class="btn-group btn-group-sm pull-right"  >
+      <a class="btn btn-default dropdown-toggle" data-toggle="dropdown" href="#"> <i class="fa fa-cog fa-fw"></i>&nbsp;Actions &nbsp;<span class="fa fa-caret-down" title="Toggle dropdown menu"></span> </a>
+      <ul class="dropdown-menu">
+        <li><a class="action-dropdown" href="/view_remote_replications/" ><i class="fa fa-list fa-fw"></i>&nbsp;Back to replications list</a></li>
+      </ul>
+    </div>
+{%endblock%}
+
+{% block inside_content %}
+
+  <form class="form-horizontal" role="form" name="pause_replication_schedule"  method="post">
+    {%csrf_token%}
+    {% if replication %} 
+    <table  class="table " style="width:800px">
+        <style>
+          th {
+              width:35%;
+          }
+        </style>
+
+        <input type="hidden" name="remote_replication_id" value="{{replication.remote_replication_id}}">
+        <input type="hidden" name="pause_cron_task_id" value="{{replication.pause_cron_task_id}}">
+        <input type="hidden" id="id_is_disabled" name="is_disabled" value=''/>
+
+        {% if replication.mode == 'zfs' %}
+
+		<tr>
+		  <th> Replicated dataset</th>
+		  <td> 
+		    {{replication.zfs.0.source_dataset}}
+		  </td>
+		</tr>
+		<tr>
+		  <th> Target IntegralSTOR IP</th>
+		  <td> 
+		    {{replication.zfs.0.target_ip}}
+		  </td>
+		</tr>
+		<tr>
+		  <th> Target IntegralSTOR pool name</th>
+		  <td> 
+		    {{replication.zfs.0.target_pool}}
+		  </td>
+		</tr>
+
+        {% elif replication.mode == 'rsync' %}
+		<tr>
+		  <th> Source path</th>
+		  <td> 
+		    {{replication.rsync.0.source_path}}
+		  </td>
+		</tr>
+		{% if replication.rsync.0.rsync_type != 'local' %}
+		  {% if replication.rsync.0.rsync_type == 'push' %}
+		    <tr>
+		      <th> Source machine</th>
+		      <td> 
+		      Local host(this machine)
+		      </td>
+		    </tr>
+		  {% elif replication.rsync.0.rsync_type == 'pull' %}
+		    <tr>
+		      <th> Source machine</th>
+		      <td> 
+		      {{replication.rsync.0.target_ip}}
+		      </td>
+		    </tr>
+		  {% endif %}
+		{% endif %}
+		<tr>
+		  <th> Target path</th>
+		  <td> 
+		    {{replication.rsync.0.target_path}}
+		  </td>
+		</tr>
+		{% if replication.rsync.0.rsync_type != 'local' %}
+
+		  {% if replication.rsync.0.rsync_type == 'pull' %}
+		    <tr>
+		      <th> Target machine</th>
+		      <td> 
+		      Local host(this machine)
+		      </td>
+		    </tr>
+		  {% elif replication.rsync.0.rsync_type == 'push' %}
+		    <tr>
+		      <th> Target machine</th>
+		      <td> 
+		      {{replication.rsync.0.target_ip}}
+		      </td>
+		    </tr>
+		  {% endif %}
+
+		{% endif %}
+
+		{% if replication.rsync.0.rsync_type == 'local' %}
+		<tr>
+		  <th> Source and target path are on local host(this machine)</th>
+		  <td> 
+		  </td>
+		</tr>
+		{% endif %}
+
+		<tr>
+                  <th> Between IntegralSTOR units? </th>
+                  <td>
+                    {% if replication.rsync.0.is_between_integralstor == 'True' %}
+                    Yes
+                    {% else %}
+                    No
+                    {% endif %}
+                  </td>
+		</tr>
+        {%endif%}
+
+        <tr>
+          <th> Replication scheduled to run at</th>
+          <td> {{replication.schedule_description}} </td>
+        </tr>
+        <tr>
+          <th> Replication scheduled to pause at</th>
+          {% if replication.pause_cron_task_id != -1 %}
+            <td> {{replication.pause_schedule_description}} </td>
+          {% else %}
+            <td> not scheduled yet! </td>
+          {% endif %}
+        </tr>
+
+        <tr>
+          <th> Run replication uninterrupted?</th>
+          <td>
+             <input id="id_is_disabled_dummy" name="is_disabled_dummy" type="checkbox" />
+          </td>
+        </tr>
+
+        <tr>
+        <th> Select a new schedule to pause replication </th>
+        <td>
+          <div id="scheduler" class="form-control" style="border:0px ">
+          </div>
+          <input name="scheduler" class="form-control" id="id_scheduler" placeholder="Select time from time selector" type="hidden" readonly>
+        </td>
+        </tr>
+    </table>
+
+    <div class="btn-group btn-group-sm" role="group" aria-label="...">
+      <a href="/view_remote_replications" role="button" class="btn btn-default"> Cancel</a>
+      <button type="submit" class="btn btn-primary" id="start">Update schedule</button>
+    </div>
+
+    {% else %}
+      Could not find what you are looking for!
+    <div class="btn-group btn-group-sm" role="group" aria-label="...">
+      <a href="/view_remote_replications" role="button" class="btn btn-default"> Cancel</a>
+    </div>
+
+    {%endif%}
+
+  </form>
+
+{%endblock%}
+
+{%block help_header%}
+  Modify remote replication's pause schedule. When replication process reaches the set pause schedule, it will pause the current attempt and continue on the next schedule.
+{%endblock%}
+
+{%block help_body%}
+{%endblock%}
+
+{% block tab_active %}
+  <script>
+   make_tab_active("view_remote_replications_tab")
+  </script>
+{% endblock %}
+
+{% block js %}
+
+  <script type="text/javascript" src="/static/js/jquery-cron-min.js"></script>
+  <link type="text/css" href="/static/css/jquery-cron.css" rel="stylesheet" />
+  <script>
+    $('#scheduler').cron({
+      onChange: function() {
+        $('#id_scheduler').val($(this).cron("value"));
+      },
+      customValues: {
+        "20 Minutes" : "*/20 * * * *",
+        "30 Minutes" : "*/30 * * * *",
+    }
+     });
+
+   // If checkbox is not checked on submit, POST will not contain that
+   // checkbox field, but we need it, so send a hidden input
+   $('#id_is_disabled_dummy').prop("checked", true)
+   $('#id_is_disabled').val('True')
+   $('#scheduler').hide()
+
+   $('#id_is_disabled_dummy').on('change', function() {
+            if($('#id_is_disabled_dummy').prop("checked")) {
+                $('#id_is_disabled').val("True")
+   		$('#scheduler').hide()
+            } else {
+                $('#id_is_disabled').val("False")
+   		$('#scheduler').show()
+            }
+	
+	
+   });
+
+  </script>
+{% endblock %}

--- a/integral_view/templates/view_remote_replications.html
+++ b/integral_view/templates/view_remote_replications.html
@@ -46,8 +46,9 @@
           <th> Source machine </th>
           <th> Target path </th>
           <th> Target machine </th>
+          <th> Pause schedule</th>
           {% endif %}
-          <th> Schedule</th>
+          <th> Run schedule</th>
           <th> Actions</th>
         </tr>
       </thead>
@@ -84,12 +85,15 @@
               <td> {{replication.rsync.0.target_path}} </td>
               <td> Local host </td>
               {% endif %}
+            <td> {{replication.pause_schedule_description}} </td>
             <td> {{replication.schedule_description}} </td>
             <td> 
               <div class="btn-group btn-group-xs pull-right" >
                 <a class="btn btn-default dropdown-toggle" data-toggle="dropdown" href="#" title="Click for pool specific actions"> <i class="fa fa-cog fa-fw"></i>Actions&nbsp;<span class="fa fa-caret-down" title="Toggle dropdown menu"></span> </a>
                 <ul class="dropdown-menu">
-                  <li> <a class="action-dropdown" href="/update_remote_replication/?remote_replication_id={{replication.remote_replication_id}}" title="Modify the parameters for this replication"><i class="fa fa-cog fa-fw"></i>&nbsp;Modify replication settings </a></li>
+                  <li> <a class="action-dropdown" href="/update_remote_replication/?remote_replication_id={{replication.remote_replication_id}}" title="Modify the parameters for this replication"><i class="fa fa-cog fa-fw"></i>&nbsp;Modify run schedule </a></li>
+                  <li class="divider"></li>
+                  <li> <a class="action-dropdown" href="/update_rsync_remote_replication_pause_schedule/?remote_replication_id={{replication.remote_replication_id}}" title="Modify the pause schedule for this replication"><i class="fa fa-cog fa-fw"></i>&nbsp;Modify pause schedule </a></li>
                   <li class="divider"></li>
                   <li><a class="action-dropdown" href="/delete_remote_replication?remote_replication_id={{replication.remote_replication_id}}" style="color:red"> <i class="fa fa-trash fa-fw"></i>&nbsp;Cancel this replication </a></li>
                 </ul>

--- a/integral_view/urls.py
+++ b/integral_view/urls.py
@@ -6,7 +6,7 @@ from integral_view.views.task_management import view_background_tasks, view_task
 
 from integral_view.views.disk_management import view_disks, identify_disk, replace_disk
 
-from integral_view.views.remote_replication_management import create_remote_replication, view_remote_replications, delete_remote_replication, update_remote_replication
+from integral_view.views.remote_replication_management import create_remote_replication, view_remote_replications, delete_remote_replication, update_remote_replication, update_rsync_remote_replication_pause_schedule
 
 from integral_view.views.ntp_management import update_ntp_settings, view_ntp_settings, sync_ntp
 
@@ -303,6 +303,8 @@ urlpatterns = patterns('',
                            login_required(create_remote_replication)),
                        url(r'^update_remote_replication/',
                            login_required(update_remote_replication)),
+                       url(r'^update_rsync_remote_replication_pause_schedule/',
+                           login_required(update_rsync_remote_replication_pause_schedule)),
                        url(r'^delete_remote_replication/',
                            login_required(delete_remote_replication)),
 

--- a/scripts/python/pause_rsync_remote_replication.py
+++ b/scripts/python/pause_rsync_remote_replication.py
@@ -1,0 +1,48 @@
+#!/usr/bin/python
+import sys
+from integralstor import remote_replication, tasks_utils, audit
+
+
+def pause_rsync_remote_replication(remote_replication_id):
+    try:
+        audit_str = ''
+        rr, err = remote_replication.get_remote_replications(
+            remote_replication_id)
+        if err:
+            raise Exception('Could not fetch replication details: %s' % err)
+
+        replication = rr[0]
+        mode = replication['mode']
+        if mode != 'rsync':
+            raise Exception('Invalid replication mode')
+
+        running_tasks, err = tasks_utils.get_tasks_by_cron_task_id(replication['cron_task_id'], get_last_by=False, status='running')
+        if err:
+            raise Exception
+        if running_tasks:
+            # stop only if task is currently running
+            ret, err = tasks_utils.stop_task(running_tasks[0]['task_id'])
+            if err:
+                raise Exception
+            audit_str = "%s has been paused" % running_tasks[0]['description']
+
+            audit.audit("stop_background_task",
+                        audit_str, None, system_initiated=True )
+    except Exception, e:
+        return False, 'Error pausing rsync remote replication task: %s' % e
+    else:
+        return True, None
+
+
+if __name__ == '__main__':
+    # print sys.argv
+    if len(sys.argv) != 2:
+        print 'Usage : python pause_rsync_remote_replication.py remote_replication_id'
+        sys.exit(-1)
+    ret, err = pause_rsync_remote_replication(sys.argv[1])
+    print ret, err
+    if err:
+        sys.exit(-1)
+    sys.exit(0)
+
+# vim: tabstop=8 softtabstop=0 expandtab ai shiftwidth=4 smarttab

--- a/site-packages/integralstor/audit.py
+++ b/site-packages/integralstor/audit.py
@@ -195,6 +195,8 @@ def _parse_audit_entry(entry):
             "stop_background_task": "Stopped background task ",
             "create_remote_replication": "Created remote replication ",
             "modify_remote_replication": "Modified remote replication ",
+            "update_rsync_remote_replication_pause_schedule": "Modified rsync remote replication pause schedule",
+            "remove_rsync_remote_replication_pause_schedule": "Removed rsync remote replication pause schedule",
             "remove_remote_replication": "Removed remote replication ",
             "task_fail": "Task failed ",
             "task_start": "Task started ",

--- a/site-packages/integralstor/remote_replication.py
+++ b/site-packages/integralstor/remote_replication.py
@@ -505,7 +505,7 @@ def update_remote_replication_schedule(remote_replication_id, schedule):
         return True, None
 
 
-def update_rsync_remote_replication_pause_schedule(remote_replication_id, schedule):
+def update_rsync_remote_replication_pause_schedule(remote_replication_id, schedule=None):
     try:
         if not (remote_replication_id):
             raise Exception('Invalid arguments')

--- a/site-packages/integralstor/remote_replication.py
+++ b/site-packages/integralstor/remote_replication.py
@@ -1,5 +1,7 @@
 from integralstor import audit, rsync, datetime_utils, scheduler_utils, tasks_utils, db, config, command
 
+import crontab
+
 
 def _replication_modes():
     """Maintains the list of available modes for remote replication
@@ -503,6 +505,93 @@ def update_remote_replication_schedule(remote_replication_id, schedule):
         return True, None
 
 
+def update_rsync_remote_replication_pause_schedule(remote_replication_id, schedule):
+    try:
+        if not (remote_replication_id):
+            raise Exception('Invalid arguments')
+
+        db_path, err = config.get_db_path()
+        if err:
+            raise Exception(err)
+        replications, err = get_remote_replications(
+            remote_replication_id)
+        if err:
+            raise Exception(err)
+        if not replications:
+            raise Exception('Specified replication definition not found')
+        replication = replications[0]
+
+        pause_cron_task_id = None
+        if 'pause_cron_task_id' in replication:
+            pause_cron_task_id = replication['pause_cron_task_id']
+        elif 'pause_cron_task_id' not in replication:
+            raise Exception('Field unavailable')
+
+        if schedule and int(pause_cron_task_id) != -1:
+            # When schedule is available and pause_cron_task_id is not -1,
+            # it's an update since a pause cron job is already available.
+            is_update, err = scheduler_utils.update_cron_schedule(
+                pause_cron_task_id, 'root', schedule[0], schedule[1], schedule[2], schedule[3], schedule[4])
+            if err:
+                raise Exception(err)
+        elif schedule and int(pause_cron_task_id) == -1:
+            # When schedule is available and pause_cron_task_id equals -1,
+            # create a pause cron job because it doesn't exist already.
+            py_scripts_path, err = config.get_python_scripts_path()
+            if err:
+                raise Exception(err)
+            command = '%s/pause_rsync_remote_replication.py %s' % (
+                py_scripts_path, remote_replication_id)
+            rep_cron_tasks, err = scheduler_utils.get_cron_tasks(replication['cron_task_id'])
+            if err:
+                raise Exception(err)
+            description = rep_cron_tasks[0]['description']
+            pause_cron_task_id, err = scheduler_utils.create_cron_task(
+                command, description, schedule[0], schedule[1], schedule[2], schedule[3], schedule[4])
+            if err:
+                raise Exception(err)
+
+            # pause_cron_task_id which defaults as -1(dummy), update with actual id.
+            cmd = "update remote_replications set pause_cron_task_id='%d' where remote_replication_id='%s'" % (
+                pause_cron_task_id, remote_replication_id)
+            rowid, err = db.execute_iud(db_path, [[cmd], ], get_rowid=True)
+            if err:
+                raise Exception(
+                    'Update attempt of replication pause schedule unsuccessfull: %s' % err)
+
+        elif pause_cron_task_id and int(pause_cron_task_id) != -1 and schedule is None:
+            # When schedule is none, remove the cron entry
+            cron = crontab.CronTab('root')
+            cron.remove_all(comment=str(pause_cron_task_id))
+            cron.write()
+
+            # reset cron_task_id to dummy value -1
+            cmd = "update remote_replications set pause_cron_task_id=-1 where remote_replication_id='%s'" % (
+                remote_replication_id)
+            rowid, err = db.execute_iud(db_path, [[cmd], ], get_rowid=True)
+            if err:
+                raise Exception(
+                    'Update attempt of replication pause schedule unsuccessfull: %s' % err)
+            cmd_list = []
+            cmd_list.append(
+                ['delete from cron_tasks where cron_task_id=%d' % pause_cron_task_id])
+            ret, err = db.execute_iud(db_path, cmd_list)
+            if err:
+                raise Exception(err)
+
+
+        elif pause_cron_task_id and int(pause_cron_task_id) == -1 and schedule is None:
+            # do nothing- this is useful for cleanup
+            pass
+        else:
+            raise Exception("Undefined condition")
+
+    except Exception, e:
+        return None, "Error updating remote replication's pause schedule: %s" % e
+    else:
+        return pause_cron_task_id, None
+
+
 def delete_remote_replication(remote_replication_id):
     try:
         db_path, err = config.get_db_path()
@@ -518,6 +607,14 @@ def delete_remote_replication(remote_replication_id):
         if not replications:
             raise Exception(
                 'Specified remote replication not found')
+
+        if replications[0]['mode'] == 'rsync':
+            remove_pause_schedule, err = update_rsync_remote_replication_pause_schedule(remote_replication_id)
+            if err:
+                raise Exception(err)
+        elif replications[0]['mode'] == 'zfs':
+            # TODO: handle this when ZFS pause/resume is brought in
+            pass
 
         cron_remove, err = scheduler_utils.delete_cron(
             int(replications[0]['cron_task_id']))
@@ -580,7 +677,15 @@ def get_remote_replications(remote_replication_id=None):
                     raise Exception(err)
                 if not cron_tasks:
                     raise Exception('Specified replication schedule not found')
+                pause_cron_tasks, err = scheduler_utils.get_cron_tasks(
+                    replication['pause_cron_task_id'])
+                if err:
+                    raise Exception(err)
                 replication['schedule_description'] = cron_tasks[0]['schedule_description']
+                if 'schedule_description' in pause_cron_tasks[0] and pause_cron_tasks[0]['schedule_description']:
+                    replication['pause_schedule_description'] = pause_cron_tasks[0]['schedule_description']
+                else:
+                    replication['pause_schedule_description'] = ''
                 replication['description'] = cron_tasks[0]['description']
                 mode_cmd = "select * from %s_replications where remote_replication_id='%s'" % (
                     replication['mode'], replication['remote_replication_id'])

--- a/site-packages/integralstor/remote_replication.py
+++ b/site-packages/integralstor/remote_replication.py
@@ -743,10 +743,8 @@ def get_remote_replications_with(mode, entries):
 
 
 def run_rsync_remote_replication(remote_replication_id):
-    """Queues the replication to tasks table
+    """Creates the replication task in tasks table and executes(runs) it
 
-    The header says 'run' though it actually only queues it and doesn't
-    execute it right away. When queued, it runs the following minute.
     """
     try:
         scripts_path, err = config.get_shell_scripts_path()
@@ -848,8 +846,13 @@ def run_rsync_remote_replication(remote_replication_id):
                                                     cmd_arg, rename_snap_cmd, create_snap_cmd, remote_replication_id)
 
         # Retry upto 3 times(default) with a retry interval of 1 hour
-        ret, err = tasks_utils.create_task(description, [
+        task_id, err = tasks_utils.create_task(description, [
             {'Replication': cmd}], task_type_id=4, run_as_user_name=run_as_user_name, retry_interval=60, cron_task_id=rr[0][0]['cron_task_id'])
+        if err:
+            raise Exception(err)
+
+        # Now run it
+        ret, err = tasks_utils.run_task(task_id)
         if err:
             raise Exception(err)
     except Exception, e:
@@ -859,10 +862,8 @@ def run_rsync_remote_replication(remote_replication_id):
 
 
 def run_zfs_remote_replication(remote_replication_id):
-    """Queues the replication to tasks table
+    """Creates the replication task in tasks table and executes(runs) it
 
-    The header says 'run' though it actually only queues it and doesn't
-    execute it right away. When queued, it runs the following minute.
     """
     try:
         scripts_path, err = config.get_shell_scripts_path()
@@ -922,8 +923,13 @@ def run_zfs_remote_replication(remote_replication_id):
             path, source_pool, source_dataset_name, target_pool, target_user_name, target_ip, remote_replication_id)
 
         # Retry upto 3 times(default) with a retry interval of 1 hour
-        ret, err = tasks_utils.create_task(description, [
+        task_id, err = tasks_utils.create_task(description, [
             {'Replication': cmd}], task_type_id=4, run_as_user_name=run_as_user_name, retry_interval=60, cron_task_id=rr[0][0]['cron_task_id'])
+        if err:
+            raise Exception(err)
+
+        # Now run it
+        ret, err = tasks_utils.run_task(task_id)
         if err:
             raise Exception(err)
 

--- a/site-packages/integralstor/tasks_utils.py
+++ b/site-packages/integralstor/tasks_utils.py
@@ -79,7 +79,7 @@ def create_task(description, subtask_list, task_type_id=0, cron_task_id=0, node=
             for subtask in subtask_list:
                 for description, command in subtask.iteritems():
                     # command = '%s  &> %s' % (command, log_file)
-                    command = '%s &> %s; tail -n 200 %s > %s.TMP && mv %s.TMP %s' % (command, log_file, log_file, log_file, log_file, log_file)
+                    command = '%s &> %s; rc=$?; tail -n 200 %s > %s.TMP && mv %s.TMP %s; exit $rc' % (command, log_file, log_file, log_file, log_file, log_file)
                     cmd = "insert into subtasks (description,command,task_id) values ('%s','%s','%d');" % (
                         description, command, row_id)
                     status, err = db.execute_iud(

--- a/site-packages/integralstor/tasks_utils.py
+++ b/site-packages/integralstor/tasks_utils.py
@@ -164,27 +164,37 @@ def get_task_pgid(task_id):
         return pgid, None
 
 
-def stop_task(task_id):
+def stop_task(task_id, mark_failed=False):
     """Terminate the process group of this task
 
     This action is applicable only for remote replication tasks(task_type_id=4)
     """
     try:
+        is_running = False
+        task, err = get_task(task_id)
+        if err:
+            raise Exception(err)
+        if int(task['task_type_id']) != 4:
+            raise Exception('Invalid task type')
+        if str(task['status']) == 'running':
+            is_running = True
         # Since task_id is the only readily availble identifier, use that to
         # retrieve relevant information. The only link between the task entry
         # and its corresponding remote_replication entry is cron_task_id. The
         # respective cron entry contains the remote_replication id embedded in
         # its command field; extract that to identify the pgid file which will
         # contain the process group id.
-        pgid, err = get_task_pgid(task_id)
-        if err:
-            raise Exception(err)
-        cmd = 'kill -- -%s' % pgid
-        ret, err = command.get_command_output(cmd, shell=True)
-        if err:
-            raise Exception("Could not terminate the process group: %s" % err)
-        time.sleep(5)
+        if is_running is True:
+            pgid, err = get_task_pgid(task_id)
+            if err:
+                raise Exception(err)
+            cmd = 'kill -- -%s' % pgid
+            ret, err = command.get_command_output(cmd, shell=True)
+            if err:
+                raise Exception("Could not terminate the process group: %s" % err)
+            time.sleep(5)
 
+        # Read again to get the updated status
         task, err = get_task(task_id)
         if err:
             raise Exception(err)
@@ -192,6 +202,19 @@ def stop_task(task_id):
         attempts = task['attempts']
         audit_str = "%s" % task['description']
         status_update = ''
+
+        db_path, err = config.get_db_path()
+        if err:
+            raise Exception(err)
+
+        if mark_failed is True:
+            # regradless of the status(running or error-retrying), mark it failed.
+            status_update = "update tasks set status = 'failed', attempts = '%d' where task_id = '%d' and status is not 'cancelled'" % (
+                0, task['task_id'])
+            status, err = db.execute_iud(
+                db_path, [[status_update], ], get_rowid=True)
+            if err:
+                raise Exception(err)
 
         # If the caller(in fn process_tasks()) had not received a return code(
         # term signal 9?), status is not updated and remains 'running', so,
@@ -206,9 +229,6 @@ def stop_task(task_id):
             else:
                 status_update = "update tasks set status = 'failed', attempts = '%d' where task_id = '%d' and status is not 'cancelled'" % (
                     0, task['task_id'])
-            db_path, err = config.get_db_path()
-            if err:
-                raise Exception(err)
             status, err = db.execute_iud(
                 db_path, [[status_update], ], get_rowid=True)
             if err:
@@ -279,7 +299,7 @@ def get_tasks(node=None):
         return tasks, None
 
 
-def get_tasks_by_cron_task_id(cron_task_id, get_last_by=False, status=None):
+def get_tasks_by_cron_task_id(cron_task_id, get_last_by=False, status_list=None):
     tasks = []
     try:
         status_qry = ''
@@ -287,8 +307,14 @@ def get_tasks_by_cron_task_id(cron_task_id, get_last_by=False, status=None):
         if err:
             raise Exception(err)
 
-        if status:
-            status_qry = 'and status="%s" ' % (str(status))
+        if status_list:
+            list_len = len(status_list)
+            for idx, status in enumerate(status_list):
+                if idx < (list_len - 1):
+                    status_qry = '%s status="%s" or ' % (status_qry, str(status))
+                elif idx == (list_len - 1):
+                    status_qry = '%s status="%s"' % (status_qry, str(status))
+            status_qry = 'and (%s)' % status_qry
         if get_last_by is False:
             query = 'select * from tasks where cron_task_id="%d" %s' % (int(
                 cron_task_id), status_qry)
@@ -495,8 +521,9 @@ def main():
     # print is_task_running(1)
     # print get_task_pgid(1)
     # print stop_task(1)
-    task, err = get_task(18)
-    print task, err
+    # task, err = get_task(18)
+    # print task, err
+    print get_tasks_by_cron_task_id(1, status_list=['running','error-retrying'])
 
 
 if __name__ == "__main__":

--- a/site-packages/integralstor/tasks_utils.py
+++ b/site-packages/integralstor/tasks_utils.py
@@ -1,4 +1,4 @@
-from integralstor import config, db, command, audit, scheduler_utils
+from integralstor import config, db, command, audit, scheduler_utils, datetime_utils
 
 import re
 import time
@@ -73,8 +73,10 @@ def create_task(description, subtask_list, task_type_id=0, cron_task_id=0, node=
         row_id, err = db.execute_iud(db_path, [[cmd], ], get_rowid=True)
         if err:
             raise Exception(err)
+        task_id = None
 
         if row_id:
+            task_id = row_id
             log_file = '%s/%d.log' % (log_dir, row_id)
             for subtask in subtask_list:
                 for description, command in subtask.iteritems():
@@ -92,7 +94,7 @@ def create_task(description, subtask_list, task_type_id=0, cron_task_id=0, node=
     except Exception, e:
         return False, ' Error adding task: %s' % e
     else:
-        return True, None
+        return task_id, None
 
 
 def delete_task(task_id):
@@ -372,6 +374,134 @@ def get_subtasks(task_id):
     else:
         return subtasks, None
 
+def run_task(task_id):
+    try:
+        task, err = get_task(task_id)
+        if err:
+            raise Exception(err)
+        now, err = datetime_utils.get_epoch(when='now')
+        if err:
+            raise Exception(err)
+        db_path, err = config.get_db_path()
+        if err:
+            raise Exception(err)
+
+
+        if task['last_run_time']:
+            seconds_since_last_run = (now - task['last_run_time'])
+            # retry_interval is in minutes!
+            if seconds_since_last_run < task['retry_interval'] * 60:
+                raise Exception("Too young to attempt")
+
+        # Mark the task as running
+        cmd = "update tasks set status = 'running', last_run_time=%d where task_id = '%d'" % (
+            now, task['task_id'])
+        status, err = db.execute_iud(
+            db_path, [[cmd], ], get_rowid=True)
+        if err:
+            raise Exception(err)
+
+        audit_str = "%s" % task['description']
+        audit.audit("task_start", audit_str,
+                    None, system_initiated=True)
+
+        attempts = task['attempts']
+        run_as_user_name = task['run_as_user_name']
+
+        # Now process subtasks for the task
+        subtasks_query = "select * from subtasks where task_id == '%d' and (status == 'error-retrying' or status == 'queued') order by subtask_id" % task[
+            'task_id']
+        subtasks, err = db.get_multiple_rows(db_path, subtasks_query)
+        if err:
+            raise Exception(err)
+
+        # Assume task is complete unless proven otherwise
+        task_completed = True
+
+        # Iteriate through all the unfinished subtasks related to the
+        # task
+        for subtask in subtasks:
+
+            subtask_id = subtask["subtask_id"]
+
+            status_update = "update subtasks set status = 'running' where subtask_id = '%d' and status is not 'cancelled'" % subtask_id
+            status, err = db.execute_iud(
+                db_path, [[status_update], ], get_rowid=True)
+            if err:
+                task_completed = False
+                break
+
+            # Now actually execute the command
+            # This task is not meant to be executed by the current user
+            # so switch to that user
+            (out, return_code), err = command.execute_with_rc(
+                subtask["command"], shell=True, run_as_user_name=run_as_user_name)
+
+            if out[0]:
+                output = re.sub("'", "", ''.join(out[0]))
+            else:
+                output = None
+            if out[1]:
+                error = re.sub("'", "", ''.join(out[1]))
+            else:
+                error = None
+
+            if return_code == 0:
+                # This means the command was successful. So update to
+                # completed
+                status_update = "update subtasks set status = 'completed', return_code='%d' where subtask_id = '%d' and status is not 'cancelled';" % (
+                    return_code, subtask_id)
+                status, err = db.execute_iud(
+                    db_path, [[status_update], ], get_rowid=True)
+                if err:
+                    task_completed = False
+                    break
+                else:
+                    continue
+            else:
+                # Subtask command failed
+                if attempts > 1 or attempts == -2:
+                    status_update = 'update subtasks set status = "error-retrying", return_code="%d" where subtask_id = "%d" and status is not "cancelled";' % (
+                        return_code, subtask_id)
+                elif attempts in [0, 1]:
+                    status_update = 'update subtasks set status = "failed", return_code="%d"" where subtask_id = "%d" and status is not "cancelled";' % (
+                        return_code, subtask_id)
+                execute, err = db.execute_iud(
+                    db_path, [[status_update], ], get_rowid=True)
+                task_completed = False
+                break
+
+        if task_completed:
+            status_update = "update tasks set status = 'completed' where task_id = '%d'" % task[
+                'task_id']
+        else:
+            if attempts > 1:
+                status_update = "update tasks set status = 'error-retrying', attempts = %d where task_id = '%d' and status is not 'cancelled'" % (
+                    attempts - 1, task['task_id'])
+            elif attempts == -2:
+                status_update = "update tasks set status = 'error-retrying', attempts = %d where task_id = '%d' and status is not 'cancelled'" % (
+                    -2, task['task_id'])
+            else:
+                status_update = "update tasks set status = 'failed', attempts = '%d' where task_id = '%d' and status is not 'cancelled'" % (
+                    0, task['task_id'])
+        status, err = db.execute_iud(
+            db_path, [[status_update], ], get_rowid=True)
+        if err:
+            raise Exception(err)
+
+        if task_completed:
+            audit.audit("task_complete", audit_str,
+                        None, system_initiated=True)
+        else:
+            audit.audit("task_fail", audit_str,
+                        None, system_initiated=True)
+
+
+    except Exception as e:
+        return False, 'Error processing task: %s' % e
+    else:
+        return True, None
+
 
 def process_tasks(node=socket.getfqdn()):
     """When called, processes/runs subtasks of each entry from tasks table if they satisfy/pass the required checks like status, last_run_time, retries, etc."""
@@ -380,13 +510,16 @@ def process_tasks(node=socket.getfqdn()):
         - Needs a better docstring comment beriefly explaning what the function does
     '''
     try:
+        error_list = []
 
         db_path, err = config.get_db_path()
         if err:
             raise Exception(err)
 
-        current_user = getpass.getuser()
-        now = int(time.time())
+        # now = int(time.time())
+        now, err = datetime_utils.get_epoch(when='now')
+        if err:
+            raise Exception(err)
 
         tasks_query = "select * from tasks where node == '" + node + \
             "' and (status == 'error-retrying' or status == 'queued') and (initiate_time <= '%d');" % (now)
@@ -395,120 +528,16 @@ def process_tasks(node=socket.getfqdn()):
             raise Exception(err)
 
         if tasks_to_process is not None:
-
             for task in tasks_to_process:
-
-                if task['last_run_time']:
-                    seconds_since_last_run = (now - task['last_run_time'])
-                    # retry_interval is in minutes!
-                    if seconds_since_last_run < task['retry_interval'] * 60:
-                        continue
-
-                # Mark the task as running
-                cmd = "update tasks set status = 'running', last_run_time=%d where task_id = '%d'" % (
-                    now, task['task_id'])
-                status, err = db.execute_iud(
-                    db_path, [[cmd], ], get_rowid=True)
+                ret, err = run_task(task['task_id'])
                 if err:
-                    raise Exception(err)
+                    error_list.append(str(err))
 
-                audit_str = "%s" % task['description']
-                audit.audit("task_start", audit_str,
-                            None, system_initiated=True)
-
-                attempts = task['attempts']
-                run_as_user_name = task['run_as_user_name']
-
-                # Now process subtasks for the task
-                subtasks_query = "select * from subtasks where task_id == '%d' and (status == 'error-retrying' or status == 'queued') order by subtask_id" % task[
-                    'task_id']
-                subtasks, err = db.get_multiple_rows(db_path, subtasks_query)
-                if err:
-                    raise Exception(err)
-
-                # Assume task is complete unless proven otherwise
-                task_completed = True
-
-                # Iteriate through all the unfinished subtasks related to the
-                # task
-                for subtask in subtasks:
-
-                    subtask_id = subtask["subtask_id"]
-
-                    status_update = "update subtasks set status = 'running' where subtask_id = '%d' and status is not 'cancelled'" % subtask_id
-                    status, err = db.execute_iud(
-                        db_path, [[status_update], ], get_rowid=True)
-                    if err:
-                        task_completed = False
-                        break
-
-                    # Now actually execute the command
-                    # This task is not meant to be executed by the current user
-                    # so switch to that user
-                    (out, return_code), err = command.execute_with_rc(
-                        subtask["command"], shell=True, run_as_user_name=run_as_user_name)
-
-                    if out[0]:
-                        output = re.sub("'", "", ''.join(out[0]))
-                    else:
-                        output = None
-                    if out[1]:
-                        error = re.sub("'", "", ''.join(out[1]))
-                    else:
-                        error = None
-
-                    if return_code == 0:
-                        # This means the command was successful. So update to
-                        # completed
-                        status_update = "update subtasks set status = 'completed', return_code='%d' where subtask_id = '%d' and status is not 'cancelled';" % (
-                            return_code, subtask_id)
-                        status, err = db.execute_iud(
-                            db_path, [[status_update], ], get_rowid=True)
-                        if err:
-                            task_completed = False
-                            break
-                        else:
-                            continue
-                    else:
-                        # Subtask command failed
-                        if attempts > 1 or attempts == -2:
-                            status_update = 'update subtasks set status = "error-retrying", return_code="%d" where subtask_id = "%d" and status is not "cancelled";' % (
-                                return_code, subtask_id)
-                        elif attempts in [0, 1]:
-                            status_update = 'update subtasks set status = "failed", return_code="%d"" where subtask_id = "%d" and status is not "cancelled";' % (
-                                return_code, subtask_id)
-                        execute, err = db.execute_iud(
-                            db_path, [[status_update], ], get_rowid=True)
-                        task_completed = False
-                        break
-
-                if task_completed:
-                    status_update = "update tasks set status = 'completed' where task_id = '%d'" % task[
-                        'task_id']
-                else:
-                    if attempts > 1:
-                        status_update = "update tasks set status = 'error-retrying', attempts = %d where task_id = '%d' and status is not 'cancelled'" % (
-                            attempts - 1, task['task_id'])
-                    elif attempts == -2:
-                        status_update = "update tasks set status = 'error-retrying', attempts = %d where task_id = '%d' and status is not 'cancelled'" % (
-                            -2, task['task_id'])
-                    else:
-                        status_update = "update tasks set status = 'failed', attempts = '%d' where task_id = '%d' and status is not 'cancelled'" % (
-                            0, task['task_id'])
-                status, err = db.execute_iud(
-                    db_path, [[status_update], ], get_rowid=True)
-                if err:
-                    raise Exception(err)
-
-                if task_completed:
-                    audit.audit("task_complete", audit_str,
-                                None, system_initiated=True)
-                else:
-                    audit.audit("task_fail", audit_str,
-                                None, system_initiated=True)
+        if error_list:
+            raise Exception(str(error_list))
 
     except Exception as e:
-        return False, 'Error processing tasks : %s' % e
+        return False, 'Error processing tasks: %s' % e
     else:
         return True, None
 
@@ -523,7 +552,8 @@ def main():
     # print stop_task(1)
     # task, err = get_task(18)
     # print task, err
-    print get_tasks_by_cron_task_id(1, status_list=['running','error-retrying'])
+    # print get_tasks_by_cron_task_id(1, status_list=['running','error-retrying'])
+    print process_tasks()
 
 
 if __name__ == "__main__":

--- a/site-packages/integralstor/tasks_utils.py
+++ b/site-packages/integralstor/tasks_utils.py
@@ -279,18 +279,22 @@ def get_tasks(node=None):
         return tasks, None
 
 
-def get_tasks_by_cron_task_id(cron_task_id, get_last_by=False):
+def get_tasks_by_cron_task_id(cron_task_id, get_last_by=False, status=None):
     tasks = []
     try:
+        status_qry = ''
         db_path, err = config.get_db_path()
         if err:
             raise Exception(err)
+
+        if status:
+            status_qry = 'and status="%s" ' % (str(status))
         if get_last_by is False:
-            query = 'select * from tasks where cron_task_id="%d"' % int(
-                cron_task_id)
+            query = 'select * from tasks where cron_task_id="%d" %s' % (int(
+                cron_task_id), status_qry)
         else:
-            query = 'select * from tasks where cron_task_id="%d" order by "%s" desc limit 1' % (
-                int(cron_task_id), str(get_last_by))
+            query = 'select * from tasks where cron_task_id="%d" %s order by "%s" desc limit 1' % (
+                int(cron_task_id), status_qry, str(get_last_by))
 
         tasks, err = db.get_multiple_rows(db_path, query)
         if err:


### PR DESCRIPTION
__Run replication tasks on schedule__

    Instead of queuing it to tasks table and exiting, proceed to execute it

    The retries are picked and handled by the process_tasks() call from
    task processor entry in cron.

__Update replication status correctly on pause__

    When the replication pause schedule is hit, if the task is
        - 'completed' or 'failed', do nothing
        - 'running', stop the executing process & update status as
          failed
        - 'error-retrying', update status as failed

__Exit with correct return code after truncating__

    After the truncating the replication task log, return with the correct
    exit code; exit code must be from the rsync replicaiton script, not the
    truncation command's.

__Introduce pause schedule for remote replications__

    Pause the replication task if it's 'running'.