### PR TITLE
Add one shot remote replication attempt

### DIFF
--- a/install/conf-files/db/integralstor_db.schema
+++ b/install/conf-files/db/integralstor_db.schema
@@ -107,7 +107,8 @@ CREATE TABLE "remote_replications" (
   "remote_replication_id" integer NOT NULL PRIMARY KEY AUTOINCREMENT,
   "mode" varchar(20) NOT NULL,
   "cron_task_id" integer NOT NULL REFERENCES cron_tasks(cron_task_id) ON DELETE CASCADE,
-  "pause_cron_task_id" integer NOT NULL DEFAULT -1 REFERENCES cron_tasks(cron_task_id)
+  "pause_cron_task_id" integer NOT NULL DEFAULT -1 REFERENCES cron_tasks(cron_task_id),
+  "is_one_shot" boolean DEFAULT 'False'
 );
 
 

--- a/integral_view/forms/remote_replication_forms.py
+++ b/integral_view/forms/remote_replication_forms.py
@@ -52,6 +52,7 @@ class RsyncMode(forms.Form):
 
 class CreateRemoteReplication(ZFSMode, RsyncMode):
     target_ip = forms.GenericIPAddressField(protocol='IPv4')
+    is_one_shot = forms.BooleanField(required=False)
 
     def __init__(self, *args, **kwargs):
         modes = []

--- a/integral_view/templates/create_remote_replication.html
+++ b/integral_view/templates/create_remote_replication.html
@@ -187,6 +187,11 @@
           <input name="scheduler" class="form-control" id="id_scheduler" placeholder="Select time from time selector" type="hidden" required readonly>
         </td>
       </tr>
+      <tr>
+       <th> One time replication: run only once at the first scheduled time </th>
+        <td> {{ form.is_one_shot }} </td>
+        <td> {{ form.is_one_shot.errors }} </td>
+      </tr>
     </table>
     <div class="btn-group btn-group-sm" role="group" aria-label="...">
       <a href="/view_remote_replications" role="button" class="btn btn-default"> Cancel</a>

--- a/integral_view/templates/update_remote_replication.html
+++ b/integral_view/templates/update_remote_replication.html
@@ -131,6 +131,19 @@
           <input name="scheduler" class="form-control" id="id_scheduler" placeholder="Select time from time selector" type="hidden" required readonly>
         </td>
         </tr>
+        <tr>
+        <td />
+        </tr>
+        <tr>
+          <th> One time replication? </th>
+          <td>
+            {% if replication.is_one_shot == 'True' %}
+            Yes
+            {% else %}
+            No
+            {% endif %}
+          </td>
+        </tr>
     </table>
 
     <div class="btn-group btn-group-sm" role="group" aria-label="...">

--- a/integral_view/templates/update_remote_replication_pause_schedule.html
+++ b/integral_view/templates/update_remote_replication_pause_schedule.html
@@ -132,6 +132,16 @@
             <td> not scheduled yet! </td>
           {% endif %}
         </tr>
+        <tr>
+          <th> One time replication? </th>
+          <td>
+            {% if replication.is_one_shot == 'True' %}
+            Yes
+            {% else %}
+            No
+            {% endif %}
+          </td>
+        </tr>
 
         <tr>
           <th> Run replication uninterrupted?</th>

--- a/scripts/shell/rsync_replicator.sh
+++ b/scripts/shell/rsync_replicator.sh
@@ -11,8 +11,14 @@ exit_code=""
 # get the process group id of this process
 pgid=$(ps -o pgid= $$ | grep -o [0-9]*)
 
+# get the process id
+pid=$(ps -o pid= $$ | grep -o [0-9]*)
+
 # store the process group id
 printf '%s' "$pgid" > /opt/integralstor/integralstor/config/run/tasks/rr."$rr_id".pgid
+
+# store the process id
+printf '%s' "$pid" > /opt/integralstor/integralstor/config/run/tasks/rr."$rr_id".pid
 
 echo "$rsync_cmd" | /bin/bash
 rsync_rc=$?
@@ -42,8 +48,9 @@ if (( "$exit_code"=="0" )); then
   fi
 fi
 
-# remove the process group id file
+# remove the process group id and pid files
 rm -f /opt/integralstor/integralstor/config/run/tasks/rr."$rr_id".pgid
+rm -f /opt/integralstor/integralstor/config/run/tasks/rr."$rr_id".pid
 
 exit $exit_code
 

--- a/site-packages/integralstor/remote_replication.py
+++ b/site-packages/integralstor/remote_replication.py
@@ -292,14 +292,18 @@ def add_remote_replication(mode, entries):
         if err:
             raise Exception(err)
 
+        is_one_shot = False
+        if 'is_one_shot' in entries and entries['is_one_shot'] == True:
+            is_one_shot = True
+
         # Since cron_task_id is a required parameter pass -1 to
         # represent its unavailability. Update when available.
         cron_task_id = -1
 
         # Insert in to remote_replications is followed by insert in to
         # appropriate mode specific replication table.
-        rr_cmd = "insert into remote_replications (cron_task_id,mode) values ('%d','%s')" % (
-            cron_task_id, mode)
+        rr_cmd = "insert into remote_replications (cron_task_id,mode,is_one_shot) values ('%d','%s','%s')" % (
+            cron_task_id, mode, is_one_shot)
         remote_replication_id, err = db.execute_iud(
             db_path, [[rr_cmd], ], get_rowid=True)
         if err:
@@ -683,6 +687,8 @@ def get_remote_replications(remote_replication_id=None):
                 if err:
                     raise Exception(err)
                 replication['schedule_description'] = cron_tasks[0]['schedule_description']
+                if replication['is_one_shot'] == 'True':
+                    replication['schedule_description'] = "[One time] %s" % replication['schedule_description']
                 if 'schedule_description' in pause_cron_tasks[0] and pause_cron_tasks[0]['schedule_description']:
                     replication['pause_schedule_description'] = pause_cron_tasks[0]['schedule_description']
                 else:
@@ -1023,17 +1029,33 @@ def run_rsync_remote_replication(remote_replication_id):
                 short_switches, long_switches, source, target)
 
         path = '%s/rsync_replicator.sh' % scripts_path
-        cmd = '/bin/bash %s "%s" "%s" "%s" "%s"' % (path,
+        # execute with a new session so that all the descendants fall
+        # within a single session. Helps tag and kill them later.
+        cmd = 'setsid /bin/bash %s "%s" "%s" "%s" "%s"' % (path,
                                                     cmd_arg, rename_snap_cmd, create_snap_cmd, remote_replication_id)
 
         # Retry upto 3 times(default) with a retry interval of 1 hour
+        # If one shot replication, attemps should be 1
+        attempts = 3
+        if replication['is_one_shot'] == 'True':
+            attempts = 1
+
         task_id, err = tasks_utils.create_task(description, [
-            {'Replication': cmd}], task_type_id=4, run_as_user_name=run_as_user_name, retry_interval=60, cron_task_id=rr[0][0]['cron_task_id'])
+            {'Replication': cmd}], task_type_id=4, run_as_user_name=run_as_user_name, attempts=attempts, retry_interval=60, cron_task_id=rr[0][0]['cron_task_id'])
         if err:
             raise Exception(err)
 
         # Now run it
         ret, err = tasks_utils.run_task(task_id)
+
+        # If it is one shot replication, remove the remote replication
+        # entry because it is not required anymore.
+        if replication['is_one_shot'] == 'True':
+            is_del, del_err = delete_remote_replication(int(remote_replication_id))
+            if del_err:
+                raise Exception("%s \n%s" % (del_err, err))
+
+        # Now check if run_task() returned any error
         if err:
             raise Exception(err)
     except Exception, e:
@@ -1100,17 +1122,33 @@ def run_zfs_remote_replication(remote_replication_id):
             raise Exception(audit_str)
 
         path = '%s/zfs_replicator.sh' % scripts_path
-        cmd = "/bin/bash %s %s %s %s %s %s %s" % (
+        # execute with a new session so that all the descendants fall
+        # within a single session. Helps tag and kill them later.
+        cmd = "setsid /bin/bash %s %s %s %s %s %s %s" % (
             path, source_pool, source_dataset_name, target_pool, target_user_name, target_ip, remote_replication_id)
 
         # Retry upto 3 times(default) with a retry interval of 1 hour
+        # If one shot replication, attemps should be 1
+        attempts = 3
+        if replication['is_one_shot'] == 'True':
+            attempts = 1
+
         task_id, err = tasks_utils.create_task(description, [
-            {'Replication': cmd}], task_type_id=4, run_as_user_name=run_as_user_name, retry_interval=60, cron_task_id=rr[0][0]['cron_task_id'])
+            {'Replication': cmd}], task_type_id=4, run_as_user_name=run_as_user_name, attempts=attempts, retry_interval=60, cron_task_id=rr[0][0]['cron_task_id'])
         if err:
             raise Exception(err)
 
         # Now run it
         ret, err = tasks_utils.run_task(task_id)
+
+        # If it is one shot replication, remove the remote replication
+        # entry because it is not required anymore.
+        if replication['is_one_shot'] == 'True':
+            is_del, del_err = delete_remote_replication(int(remote_replication_id))
+            if del_err:
+                raise Exception("%s \n%s" % (del_err, err))
+
+        # Now check if run_task() returned any error
         if err:
             raise Exception(err)
 

--- a/site-packages/integralstor/scheduler_utils.py
+++ b/site-packages/integralstor/scheduler_utils.py
@@ -131,11 +131,11 @@ def delete_cron(cron_task_id, user='root'):
         cmd_list.append(
             ['delete from cron_tasks where cron_task_id=%d' % cron_task_id])
         cmd_list.append(
-            ['update tasks set status="cancelled" where cron_task_id=%s and status is not "completed"' % cron_task_id])
+            ['update tasks set status="cancelled" where cron_task_id=%s and (status is not "completed" and status is not "failed")' % cron_task_id])
         if tasks:
             for task in tasks:
                 cmd_list.append(
-                    ['update subtasks set status="cancelled" where task_id=%d  and status is not "completed"' % task['task_id']])
+                    ['update subtasks set status="cancelled" where task_id=%d  and (status is not "completed" and status is not "failed")' % task['task_id']])
 
         ret, err = db.execute_iud(db_path, cmd_list)
         if err:

--- a/site-packages/integralstor/tasks_utils.py
+++ b/site-packages/integralstor/tasks_utils.py
@@ -124,6 +124,48 @@ def delete_task(task_id):
         return True, None
 
 
+def get_task_pid(task_id):
+    """Identify the process id of this task
+
+    This action is applicable only for remote replication tasks(task_type_id=4)
+    """
+    pid = ''
+    try:
+        pid_dir_path, err = config.get_tasks_pid_dir()
+        if err:
+            raise Exception(err)
+        task, err = get_task(task_id)
+        if err:
+            raise Exception(err)
+        cron_task_id = task['cron_task_id']
+        task_type_id = task['task_type_id']
+        if task_type_id != 4:
+            raise Exception("Not a remote replication task")
+        cron_entry, err = scheduler_utils.get_cron_tasks(cron_task_id)
+        if err:
+            raise Exception(err)
+        rr_cmd_str = str(cron_entry[0]['command']).strip()
+
+        # extract the remote replication id
+        rr_id = rr_cmd_str.split()[1]
+
+        pid_file_path = '%s/rr.%s.pid' % (pid_dir_path, rr_id)
+        ret, err = command.get_command_output(
+            'cat %s' % pid_file_path, shell=True)
+        if err:
+            raise Exception("Could not identify the process instance")
+
+        if ret and ret[0]:
+            pid = ret[0]
+        else:
+            raise Exception("Could not identify the process instance")
+
+    except Exception, e:
+        return False, 'Error fetching pid: %s' % e
+    else:
+        return pid, None
+
+
 def get_task_pgid(task_id):
     """Identify the process group id of this task
 
@@ -166,13 +208,15 @@ def get_task_pgid(task_id):
         return pgid, None
 
 
-def stop_task(task_id, mark_failed=False):
-    """Terminate the process group of this task
+def stop_task(task_id, by_pgid=False, mark_failed=False):
+    """Terminate this task
 
     This action is applicable only for remote replication tasks(task_type_id=4)
     """
     try:
         is_running = False
+        cmd = ''
+        kill_id = 0
         task, err = get_task(task_id)
         if err:
             raise Exception(err)
@@ -187,10 +231,22 @@ def stop_task(task_id, mark_failed=False):
         # its command field; extract that to identify the pgid file which will
         # contain the process group id.
         if is_running is True:
-            pgid, err = get_task_pgid(task_id)
-            if err:
-                raise Exception(err)
-            cmd = 'kill -- -%s' % pgid
+            if by_pgid == True:
+                # This kills the entire process group, task status
+                # updates are not guaranteed
+                kill_id, err = get_task_pgid(task_id)
+                if err:
+                    raise Exception(err)
+                cmd = 'kill -- -%s' % kill_id
+            else:
+                # safely kill all proccess in the session of the passed
+                # pid. In replication's case, it's the executing shell
+                # script's pid which was spawned under a separate
+                # session.
+                kill_id, err = get_task_pid(task_id)
+                if err:
+                    raise Exception(err)
+                cmd = 'kill $(ps -s %s -o pid= | grep -o [0-9]*)' % kill_id
             ret, err = command.get_command_output(cmd, shell=True)
             if err:
                 raise Exception("Could not terminate the process group: %s" % err)
@@ -464,7 +520,7 @@ def run_task(task_id):
                     status_update = 'update subtasks set status = "error-retrying", return_code="%d" where subtask_id = "%d" and status is not "cancelled";' % (
                         return_code, subtask_id)
                 elif attempts in [0, 1]:
-                    status_update = 'update subtasks set status = "failed", return_code="%d"" where subtask_id = "%d" and status is not "cancelled";' % (
+                    status_update = 'update subtasks set status = "failed", return_code="%d" where subtask_id = "%d" and status is not "cancelled";' % (
                         return_code, subtask_id)
                 execute, err = db.execute_iud(
                     db_path, [[status_update], ], get_rowid=True)


### PR DESCRIPTION
        - At the scheduled time, do an one shot remote replication
        - No reattempts are made post the initial attempt
        - Pause schedule can also be set for one shot replicaitons
        - After the task has finished its run(or aborted), regardless
          of its completion status, the remote replication schedule is
          removed

Signed-off-by: six-k <ramsri.hp@gmail.com>