### PR TITLE
Add additional rsync switches to IV

### DIFF
--- a/integral_view/templates/create_remote_replication.html
+++ b/integral_view/templates/create_remote_replication.html
@@ -280,7 +280,14 @@
 
         // Select recommended options
 	$('#id_archive').prop("checked",true);
+	$('#id_hard_links').prop("checked",true);
 	$('#id_compress').prop("checked",true);
+	$('#id_partial').prop("checked",true);
+	$('#id_progress').prop("checked",true);
+	$('#id_times').prop("checked",true);
+	$('#id_links').prop("checked",true);
+	$('#id_delete').prop("checked",true);
+	$('#id_force').prop("checked",true);
 	// $('#id_verbose').prop("checked",true);
     });
 

--- a/site-packages/integralstor/remote_replication.py
+++ b/site-packages/integralstor/remote_replication.py
@@ -1022,10 +1022,10 @@ def run_rsync_remote_replication(remote_replication_id):
 
         cmd_arg = ''
         if rsync_type in ['push', 'pull']:
-            cmd_arg = 'sudo rsync -hiOP %s %s --stats -e \\"ssh -l %s -i /home/%s/.ssh/id_rsa -o UserKnownHostsFile=/home/%s/.ssh/known_hosts -o ServerAliveInterval=300 -o ServerAliveCountMax=3\\" %s %s' % (
+            cmd_arg = 'sudo rsync -hi %s %s --stats -e \\"ssh -l %s -i /home/%s/.ssh/id_rsa -o UserKnownHostsFile=/home/%s/.ssh/known_hosts -o ServerAliveInterval=300 -o ServerAliveCountMax=3\\" %s %s' % (
                 short_switches, long_switches, run_as_user_name, run_as_user_name, run_as_user_name, source, target)
         elif rsync_type in ['local']:
-            cmd_arg = 'rsync -hiOP %s %s --stats %s %s' % (
+            cmd_arg = 'rsync -hi %s %s --stats %s %s' % (
                 short_switches, long_switches, source, target)
 
         path = '%s/rsync_replicator.sh' % scripts_path

--- a/site-packages/integralstor/rsync.py
+++ b/site-packages/integralstor/rsync.py
@@ -27,6 +27,24 @@ def get_available_switches():
                 'is_arg': False,
                 'arg_value': None
             },
+            '-R': {
+                'name': 'Relative',
+                'id': 'relative',
+                'key': '-R',
+                'description': 'Use relative path names',
+                'is_long': False,
+                'is_arg': False,
+                'arg_value': None
+            },
+            '-l': {
+                'name': 'Links',
+                'id': 'links',
+                'key': '-l',
+                'description': 'Copy symlinks as symlinks',
+                'is_long': False,
+                'is_arg': False,
+                'arg_value': None
+            },
             '-L': {
                 'name': 'Copy links',
                 'id': 'copy_links',
@@ -42,6 +60,69 @@ def get_available_switches():
                 'key': '--copy-unsafe-links',
                 'description': 'Copy only the referent of symbolic links that point outside the copied tree',
                 'is_long': True,
+                'is_arg': False,
+                'arg_value': None
+            },
+            '-k': {
+                'name': 'Copy dir links',
+                'id': 'copy_dirlinks',
+                'key': '-k',
+                'description': 'Transform symlink to dir into referent dir',
+                'is_long': False,
+                'is_arg': False,
+                'arg_value': None
+            },
+            '-K': {
+                'name': 'Keep dir links',
+                'id': 'keep_dirlinks',
+                'key': '-K',
+                'description': 'Treat symlinked dir on receiver as dir',
+                'is_long': False,
+                'is_arg': False,
+                'arg_value': None
+            },
+            '-H': {
+                'name': 'Preserve hard links',
+                'id': 'hard_links',
+                'key': '-H',
+                'description': 'Preserve hard links',
+                'is_long': False,
+                'is_arg': False,
+                'arg_value': None
+            },
+            '-E': {
+                'name': 'Executability',
+                'id': 'executability',
+                'key': '-R',
+                'description': 'Preserve executability',
+                'is_long': False,
+                'is_arg': False,
+                'arg_value': None
+            },
+            '-t': {
+                'name': 'Times',
+                'id': 'times',
+                'key': '-t',
+                'description': 'Preserve modification times',
+                'is_long': False,
+                'is_arg': False,
+                'arg_value': None
+            },
+            '-O': {
+                'name': 'Omit dir times',
+                'id': 'omit_dir_times',
+                'key': '-O',
+                'description': 'Omit directories while preserving modification times',
+                'is_long': False,
+                'is_arg': False,
+                'arg_value': None
+            },
+            '-x': {
+                'name': 'One filesystem',
+                'id': 'one_file_system',
+                'key': '-x',
+                'description': 'Do not cross filesystem boundaries',
+                'is_long': False,
                 'is_arg': False,
                 'arg_value': None
             },
@@ -72,11 +153,47 @@ def get_available_switches():
                 'is_arg': True,
                 'arg_value': None
             },
+            '--temp-dir': {
+                'name': 'Temprorary dir',
+                'id': 'temp_dir',
+                'key': '--temp-dir',
+                'description': 'Create temporary files in the specified directory',
+                'is_long': True,
+                'is_arg': True,
+                'arg_value': None
+            },
             '--delete': {
                 'name': 'Delete',
                 'id': 'delete',
                 'key': '--delete',
                 'description': 'Delete extraneous files from destination dirs',
+                'is_long': True,
+                'is_arg': False,
+                'arg_value': None
+            },
+            '--force': {
+                'name': 'Force',
+                'id': 'force',
+                'key': '--force',
+                'description': 'Force deletion of dirs even if not empty',
+                'is_long': True,
+                'is_arg': False,
+                'arg_value': None
+            },
+            '--partial': {
+                'name': 'Partial',
+                'id': 'partial',
+                'key': '--partial',
+                'description': 'Keep partially transferred files',
+                'is_long': True,
+                'is_arg': False,
+                'arg_value': None
+            },
+            '--progress': {
+                'name': 'Progress',
+                'id': 'progress',
+                'key': '--progress',
+                'description': 'Show progress during transfer',
                 'is_long': True,
                 'is_arg': False,
                 'arg_value': None


### PR DESCRIPTION
Include few more relevant rsync switches and default select essential
ones while scheduling a remote replication from IV.

Signed-off-by: six-k <ramsri.hp@gmail.com>