### PR TITLE
Set default ACLs for integralstor group

### DIFF
--- a/platform
+++ b/platform
@@ -1,3 +1,3 @@
 {"platform":"integralstor",
- "version":"v1.5",
+ "version":"master-devel",
  "hardware_vendor":""}

--- a/site-packages/integralstor/zfs.py
+++ b/site-packages/integralstor/zfs.py
@@ -1087,8 +1087,10 @@ def create_dataset(parent, ds_name, properties):
         os.chown('/%s' % path, -1, owner_gid)
         os.chmod('/%s' % path, stat.S_IWUSR | stat.S_IRUSR | stat.S_IXUSR |
                  stat.S_IRGRP | stat.S_IWGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH | stat.S_ISGID)
-        os.system('setfacl -d -m g::rwx /%s' % path)
-        os.system('setfacl -d -m o::rx /%s' % path)
+        os.system('setfacl -d -m g:integralstor:rwx /%s' % path)
+        # Not required
+        # os.system('setfacl -d -m g::rwx /%s' % path)
+        # os.system('setfacl -d -m o::rx /%s' % path)
     except Exception, e:
         return False, 'Error creating dataset : %s ' % str(e)
     else:


### PR DESCRIPTION
Default rwx for integralstor group on creating a new ZFS filesystem

Signed-off-by: six-k <ramsri.hp@gmail.com>