### PR TITLE
Provide description of rsync flags that were set

### DIFF
--- a/integral_view/templates/update_remote_replication.html
+++ b/integral_view/templates/update_remote_replication.html
@@ -108,6 +108,24 @@
 		{% endif %}
 
 		<tr>
+                  <th> Rsync flags that were set </th>
+                <td>
+		{% if rsync_switches_description %}
+                  <ul >
+                    {% for k,v in rsync_switches_description.items %}
+                    <li>
+                        {{v.description}} {%if v.is_arg%} [{{v.arg_value}}] {%endif%}
+                    </li>
+                    {% endfor %}
+                  </ul>
+                {% else %}
+                        None
+		{% endif %}
+                </td>
+                </tr>
+
+
+		<tr>
                   <th> Between IntegralSTOR units? </th>
                   <td>
                     {% if replication.rsync.0.is_between_integralstor == 'True' %}

--- a/integral_view/templates/update_remote_replication_pause_schedule.html
+++ b/integral_view/templates/update_remote_replication_pause_schedule.html
@@ -108,6 +108,23 @@
 		</tr>
 		{% endif %}
 
+                <tr>
+                  <th> Rsync flags that were set </th>
+                <td>
+                {% if rsync_switches_description %}
+                  <ul >
+                    {% for k,v in rsync_switches_description.items %}
+                    <li>
+                        {{v.description}} {%if v.is_arg%} [{{v.arg_value}}] {%endif%}
+                    </li>
+                    {% endfor %}
+                  </ul>
+                {% else %}
+                        None
+                {% endif %}
+                </td>
+                </tr>
+
 		<tr>
                   <th> Between IntegralSTOR units? </th>
                   <td>

--- a/integral_view/views/remote_replication_management.py
+++ b/integral_view/views/remote_replication_management.py
@@ -387,6 +387,15 @@ def update_remote_replication(request):
 
         if request.method == "GET":
             return_dict['replication'] = replications[0]
+            if return_dict['replication']['mode'] == 'rsync':
+                rsync_switches = {}
+                rsync_switches['long'] = return_dict['replication']['rsync'][0]['long_switches']
+                rsync_switches['short'] = return_dict['replication']['rsync'][0]['short_switches']
+
+                return_dict['rsync_switches_description'], err = rsync.form_switches_description(rsync_switches)
+                if err:
+                    raise Exception('Could not parse rsync switches description: %s' % err)
+
             return django.shortcuts.render_to_response('update_remote_replication.html', return_dict, context_instance=django.template.context.RequestContext(request))
         elif request.method == "POST":
             if ('scheduler' and 'cron_task_id') not in request.POST:
@@ -446,6 +455,15 @@ def update_rsync_remote_replication_pause_schedule(request):
 
         if request.method == "GET":
             return_dict['replication'] = replications[0]
+            if return_dict['replication']['mode'] == 'rsync':
+                rsync_switches = {}
+                rsync_switches['long'] = return_dict['replication']['rsync'][0]['long_switches']
+                rsync_switches['short'] = return_dict['replication']['rsync'][0]['short_switches']
+
+                return_dict['rsync_switches_description'], err = rsync.form_switches_description(rsync_switches)
+                if err:
+                    raise Exception('Could not parse rsync switches description: %s' % err)
+
             return django.shortcuts.render_to_response('update_remote_replication_pause_schedule.html', return_dict, context_instance=django.template.context.RequestContext(request))
         elif request.method == "POST":
             scheduler = None

--- a/site-packages/integralstor/rsync.py
+++ b/site-packages/integralstor/rsync.py
@@ -288,6 +288,86 @@ def form_switches_command(switches):
         return switches_formed, None
 
 
+def form_switches_description(rsync_ready_switches):
+    """Form the switches to a format that can be passed to the rsync
+     command
+
+    args:       a dict with two keys:short and long, and its values
+                that are rsync command ready- from 
+                form_switches_command()
+
+    returns:    a dict containing switches parsed from
+                rsync_ready_switches. The dictionary will be of the
+                same semantics as the one returned by
+                get_available_swithces()
+
+    """
+
+    import re
+    switches_description = {}
+    try:
+        if not rsync_ready_switches:
+            raise Exception('Malformed switches')
+
+        avail_switches, err = get_available_switches()
+        if err:
+            raise Exception(err)
+        switches_description = avail_switches
+
+        rrs = rsync_ready_switches
+        rrs['short'] = rrs['short'].strip()
+        rrs['long'] = rrs['long'].strip()
+
+        for k, v in avail_switches.items():
+            if v['is_long'] == False:
+                # switch is short
+                if(re.search(v['key'], rrs['short'])):
+                    # this switch is set, update the arg value if
+                    # present.
+                    if (v['is_arg'] == True):
+                        # this parsing gets dirty
+                        # TODO: Handle escaped quotes well, check for buffer
+                        # overflow
+                        # get the arg value with key: --key="val")
+                        key_val = re.findall(r'%s="(?:[^"\\]*(?:\\.)?)*"\s*' % v['key'], rrs['long'])[0]
+                        key_val = key_val.strip()
+                        # now get the value alone without the prefixed key and
+                        # get rid of the quotes
+                        val = key_val.split('%s="' % v['key'])[1]
+                        val = val[:-1]
+
+                        switches_description['%s' % v['key']]['arg_value'] = val.strip()
+                else:
+                    # this switch is not set, remove it.
+                    switches_description.pop(k)
+            else:
+                if(re.search(v['key'], rrs['long'])):
+                    # this switch is set, update the arg value if
+                    # present.
+                    if (v['is_arg'] == True):
+                        # this parsing gets dirty
+                        # TODO: Handle escaped quotes well, check for buffer
+                        # overflow
+                        # get the arg value with key: --key="val")
+                        # key_val = re.findall(r'%s="(?:[^"\\]|\\.)*"\s*' % v['key'], rrs['long'])[0]
+                        key_val = re.findall(r'%s="(?:[^"\\]*(?:\\.)?)*"\s*' % v['key'], rrs['long'])[0]
+                        key_val = key_val.strip()
+                        # now get the value alone without the prefixed key and
+                        # get rid of the quotes
+                        val = key_val.split('%s="' % v['key'])[1]
+                        val = val[:-1]
+
+                        switches_description['%s' % v['key']]['arg_value'] = r'%s' % val.strip()
+                else:
+                    # this switch is not set, remove it.
+                    switches_description.pop(k)
+
+    except Exception, e:
+        return None, str(e)
+    else:
+        return switches_description, None
+
+
 def form_rsync_paths_command(rsync_type, source, target, remote_ip, remote_user_name):
     """Form 'source_path' and 'target_path' in a format that is rsync command ready
 
@@ -475,9 +555,10 @@ def main():
     # print load_shares_list()
     # print delete_rsync_share("test")
     # print _generate_rsync_config()
-    print form_rsync_paths_command('pull', '/tank/ds1', '/tar-tank/ds1', '2.2.2.2', 'replicator')
-    print form_rsync_paths_command('push', '/tank/ds1', '/tar-tank/ds1', '2.2.2.2', 'replicator')
-    print form_rsync_paths_command('local', '/tank/ds1', '/tar-tank/ds1', '2.2.2.2', 'replicator')
+    # print form_rsync_paths_command('pull', '/tank/ds1', '/tar-tank/ds1', '2.2.2.2', 'replicator')
+    # print form_rsync_paths_command('push', '/tank/ds1', '/tar-tank/ds1', '2.2.2.2', 'replicator')
+    # print form_rsync_paths_command('local', '/tank/ds1', '/tar-tank/ds1', '2.2.2.2', 'replicator')
+    form_switches_description({'short': '-t -a -l -H -z', 'long': r'--force --partial --progress --temp-dir="\dfdf\f\"xxx \"  f\"d/dddd x/" --delete'})
     """
     sw, err = get_available_switches()
     print sw


### PR DESCRIPTION
A list of all the rsync flags that were set while creating a remote
replication is displayed at /update_remote_replication/ and
/update_rsync_remote_replication_pause_schedule/

Signed-off-by: six-k <ramsri.hp@gmail.com>