### PR TITLE
able to remove user and group quota and getting quota details 

### DIFF
--- a/integral_view/views/zfs_management.py
+++ b/integral_view/views/zfs_management.py
@@ -343,7 +343,7 @@ def delete_zfs_quota(request):
         path_type = req_ret['path_type']
         path = req_ret['path']
         ug_type = req_ret['ug_type']
-        ug_name = req_ret['ug_type']
+        ug_name = req_ret['ug_name']
         pool_name = req_ret['pool_name']
 
         return_dict["path"] = path

--- a/site-packages/integralstor/zfs.py
+++ b/site-packages/integralstor/zfs.py
@@ -2420,22 +2420,22 @@ def get_all_quotas(path):
         if not path:
             raise Exception('Path not specified')
         lines = []
-        lines1, err = command.get_command_output('zfs userspace %s' % path)
+        lines1, err = command.get_command_output('zfs userspace -o name,quota %s' % path)
         if err:
             raise Exception(err)
         if lines1:
             for line in lines1[1:]:
                 comps = line.split()
                 if comps and comps[-1] != 'none':
-                    users[comps[-3]] = comps[-1]
-        lines2, err = command.get_command_output('zfs groupspace %s' % path)
+                    users[comps[-2]] = comps[-1]
+        lines2, err = command.get_command_output('zfs groupspace -o name,quota %s' % path)
         if err:
             raise Exception(err)
         if lines2:
             for line in lines2[1:]:
                 comps = line.split()
                 if comps and comps[-1] != 'none':
-                    groups[comps[-3]] = comps[-1]
+                    groups[comps[-2]] = comps[-1]
         quotas['users'] = users
         quotas['groups'] = groups
     except Exception, e:


### PR DESCRIPTION
commit 55d4ac4 - parsing the user and group name instead of type while removing the user and group quota. 
commit 30d348c - getting only the name(user/ group), and quota to view user/group quota details.

Addresses: #416 