### PR TITLE
Adds Username field to AD authentication screen

### DIFF
--- a/integral_view/core/storage_access/forms/samba_shares_forms.py
+++ b/integral_view/core/storage_access/forms/samba_shares_forms.py
@@ -11,6 +11,7 @@ class AuthADSettingsForm(forms.Form):
     password = forms.CharField(widget=forms.PasswordInput())
     realm = forms.CharField()
     workgroup = forms.CharField()
+    username = forms.CharField()
     password_server = forms.CharField()
     password_server_ip = forms.CharField()
     netbios_name = forms.CharField()

--- a/integral_view/core/storage_access/templates/update_samba_server_settings.html
+++ b/integral_view/core/storage_access/templates/update_samba_server_settings.html
@@ -35,9 +35,16 @@
           <td> {{ form.realm.errors }} </td>
         </tr>
         <tr>
-          <td> <b>AD Admininstrator password </b><br> (Never stored. Used only to initially join AD realm) </td>
+          <th> AD Server Username: </th>
           <td>
-            <input type="password"  name="password" class="form-control" id="id_password" placeholder="AD Administrator password"> 
+            <input type="text"  name="username" class="form-control" id="user_name" placeholder="AD Server Username" value="{{form.username.value|default_if_none:''}}">
+          </td>
+          <td>{{ form.username.errors }}</td>
+        </tr>
+        <tr>
+          <td> <b>AD User password </b><br> (Never stored. Used only to initially join AD realm) </td>
+          <td>
+            <input type="password"  name="password" class="form-control" id="id_password" placeholder="AD User password"> 
           </td>
           <td> {{ form.password.errors }} </td>
         </tr>

--- a/integral_view/core/storage_access/templates/update_samba_server_settings.html
+++ b/integral_view/core/storage_access/templates/update_samba_server_settings.html
@@ -35,14 +35,14 @@
           <td> {{ form.realm.errors }} </td>
         </tr>
         <tr>
-          <th> AD Server Username: </th>
+          <th> AD Administrator's Username: </th>
           <td>
-            <input type="text"  name="username" class="form-control" id="user_name" placeholder="AD Server Username" value="{{form.username.value|default_if_none:''}}">
+            <input type="text"  name="username" class="form-control" id="id_username" placeholder="Enter AD Admnistrator's username" value="{{form.username.value|default_if_none:''}}">
           </td>
           <td>{{ form.username.errors }}</td>
         </tr>
         <tr>
-          <td> <b>AD User password </b><br> (Never stored. Used only to initially join AD realm) </td>
+          <td> <b>AD Administrator's Password </b><br> (Never stored. Used only to initially join AD realm) </td>
           <td>
             <input type="password"  name="password" class="form-control" id="id_password" placeholder="AD User password"> 
           </td>

--- a/integral_view/core/storage_access/views/cifs_share_management.py
+++ b/integral_view/core/storage_access/views/cifs_share_management.py
@@ -514,13 +514,23 @@ def update_samba_server_settings(request):
                     raise Exception(err)
                 if cd["security"] == "ads":
                     rc, err = cifs.kinit(
-                        "administrator", cd["password"], cd["realm"])
+                        cd["username"], cd["password"], cd["realm"])
                     if err:
-                        raise Exception(err)
+                        if "Password incorrect" in err:
+                            raise Exception("Invalid Credentials, Please try again")
+                        elif "not found" in err:
+                            raise Exception("Could not find an Active Directory user with the username: '%s'! " % cd["username"])
+                        elif cd["password"] in err:
+                            raise Exception(err.split('echo')[0])
+                        else:
+                            raise Exception(err)
                     rc, err = cifs.net_ads_join(
-                        "administrator", cd["password"], cd["password_server"])
+                       cd["username"], cd["password"], cd["password_server"])
                     if err:
-                        raise Exception(err)
+                        if cd["password"] in err:
+                            raise Exception(err.split('net')[0])
+                        else:
+                            raise Exception(err)
                 ret, err = cifs.reload_configuration()
                 if err:
                     raise Exception(err)


### PR DESCRIPTION
AD authentication screen uses administrator user by default to bind to an AD server, these changes adds an Username field so that users have an option to use any privileged user to bind to the AD server. Exception messages have also been modified to inform user about incorrect username and password.  (Addresses issue - #438)