### PR TITLE
Fix for issue #450

### DIFF
--- a/site-packages/integralstor/disks.py
+++ b/site-packages/integralstor/disks.py
@@ -228,8 +228,6 @@ def get_partitions(disk_name):
                 continue
             name = os.path.split(os.path.normpath(
                 os.path.realpath('/dev/disk/by-id/%s' % id1)))[1]
-            if disk_name not in name:
-                continue
             if 'part' not in id1:
                 continue
             if re.findall(r'%s\d+' % disk_name, name):

--- a/site-packages/integralstor/disks.py
+++ b/site-packages/integralstor/disks.py
@@ -232,14 +232,15 @@ def get_partitions(disk_name):
                 continue
             if 'part' not in id1:
                 continue
-            d = {}
-            d['name'] = name
-            capacity, err = get_capacity(name)
-            if err:
-                raise Exception(err)
-            if capacity:
-                d["capacity"] = capacity
-            l.append(d)
+            if re.findall(r'%s\d+' % disk_name, name):
+                d = {}
+                d['name'] = name
+                capacity, err = get_capacity(name)
+                if err:
+                    raise Exception(err)
+                if capacity:
+                    d["capacity"] = capacity
+                l.append(d)
     except Exception, e:
         return None, "Error retrieving partitions : %s" % str(e)
     else:


### PR DESCRIPTION
PR addresses issue #450 where a data disk was showing up under OS disk screen, this is caused by `if disk_name not in name:` in `get_partitions()`. If `sda` is present in `name` and if `not in` evaluates against a `disk_name` containing a drive with the name `sdaa`, the drive will be considered as a OS disk. I've added a check to ensure that the whole disk name is compared before considering it as an OS disk.