### PR TITLE
Fix for issue #454

### DIFF
--- a/site-packages/integralstor/disks.py
+++ b/site-packages/integralstor/disks.py
@@ -512,12 +512,14 @@ def get_disk_status(disk_name):
             disk_dict['name'] = disk_name
             disk_dict['path'] = '/dev/%s' % disk_name
             if hw_platform and hw_platform == 'dell':
-                if disk_hw_info_all and disk_dict['serial_number'] in disk_hw_info_all.keys():
-                    serial_number = disk_dict['serial_number']
-                    disk_dict['target_id'] = disk_hw_info_all[serial_number]['target_id']
-                    disk_dict['controller_number'] = disk_hw_info_all[serial_number]['controller_number']
-                    disk_dict['enclosure_id'] = disk_hw_info_all[serial_number]['enclosure_id']
-                    disk_dict['channel'] = disk_hw_info_all[serial_number]['channel']
+                if disk_hw_info_all:
+                    for si_no in disk_hw_info_all.keys():
+                        if si_no in disk_dict['serial_number']:
+                            serial_number = si_no
+                            disk_dict['target_id'] = disk_hw_info_all[serial_number]['target_id']
+                            disk_dict['controller_number'] = disk_hw_info_all[serial_number]['controller_number']
+                            disk_dict['enclosure_id'] = disk_hw_info_all[serial_number]['enclosure_id']
+                            disk_dict['channel'] = disk_hw_info_all[serial_number]['channel']
     except Exception, e:
         return None, "Error getting disk status : %s" % str(e)
     else:

--- a/site-packages/integralstor/disks.py
+++ b/site-packages/integralstor/disks.py
@@ -514,7 +514,7 @@ def get_disk_status(disk_name):
             if hw_platform and hw_platform == 'dell':
                 if disk_hw_info_all:
                     for si_no in disk_hw_info_all.keys():
-                        if si_no in disk_dict['serial_number']:
+                        if si_no in disk_dict['serial_number'] or disk_dict['serial_number'] in si_no:
                             serial_number = si_no
                             disk_dict['target_id'] = disk_hw_info_all[serial_number]['target_id']
                             disk_dict['controller_number'] = disk_hw_info_all[serial_number]['controller_number']


### PR DESCRIPTION
Modified the comparisons in `get_disk_status()` to address both short and long version of disk serial number reported by `udevadmn` and `omreport`.