### PR TITLE
Fix for issue #429

### DIFF
--- a/site-packages/integralstor/vsftp.py
+++ b/site-packages/integralstor/vsftp.py
@@ -90,6 +90,7 @@ def update_ftp_config(config):
             f.write('xferlog_std_format=YES\n')
             f.write('ftpd_banner=Welcome to the IntegralStor FTP service.\n')
             f.write('chroot_local_user=YES\n')
+            f.write('reverse_lookup_enable=NO\n')
             # f.write('user_config_dir=/etc/vsftpd/users\n')
             f.write('local_root=/%s/$USER\n' % config['dataset'])
             f.write('user_sub_token=$USER\n')


### PR DESCRIPTION
Adds reverse_lookup_enable=NO to vsftpd.conf, which disables vsftpd's default behaviour of trying to do a reverse DNS lookup of the client before prompting for user authentication. Few clients will close the connection If the lookup fails or takes too long to complete.